### PR TITLE
docs: components standards section

### DIFF
--- a/src/content/docs/componentes/controlado-vs-no-controlado.mdx
+++ b/src/content/docs/componentes/controlado-vs-no-controlado.mdx
@@ -1,0 +1,125 @@
+---
+title: Controlado vs no controlado
+description: Cuándo y cómo usar cada patrón
+section: Componentes
+order: 15
+---
+
+# Controlado vs no controlado
+
+La diferencia entre ambos patrones está en quién posee el estado: el padre o el componente mismo.
+
+## Componente no controlado
+
+El estado vive dentro del componente. El padre lo instancia y lo olvida.
+
+```typescript
+// El componente gestiona su propio estado
+export const Counter = ({ initialValue = 0 }: CounterProps): JSX.Element => {
+  const { count, handleIncrement, handleDecrement } = useControllerCounter({
+    initialValue,
+    min: 0,
+    max: 100,
+  })
+
+  return (
+    <div>
+      <button onClick={handleDecrement}>−</button>
+      <span>{count}</span>
+      <button onClick={handleIncrement}>+</button>
+    </div>
+  )
+}
+
+// El padre no controla el valor
+<Counter initialValue={5} />
+```
+
+**Cuándo usarlo:** componentes de UI autónomos sin necesidad de sincronización externa. Tooltips, dropdowns de decoración, contadores de demostración.
+
+## Componente controlado
+
+El estado vive en el padre. El componente recibe `value` y notifica cambios con `onChange`.
+
+```typescript
+export interface SearchInputProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder?: string
+}
+
+export const SearchInput = ({
+  value,
+  onChange,
+  placeholder,
+}: SearchInputProps): JSX.Element => {
+  const { handleChange, handleClear } = useControllerSearchInput({ onChange })
+
+  return (
+    <div className="relative">
+      <input
+        value={value}
+        onChange={handleChange}
+        placeholder={placeholder}
+      />
+      {value && (
+        <button onClick={handleClear}>✕</button>
+      )}
+    </div>
+  )
+}
+
+// El padre controla el estado
+const [query, setQuery] = useState('')
+<SearchInput value={query} onChange={setQuery} />
+```
+
+**Cuándo usarlo:** cuando el padre necesita conocer o modificar el estado del componente, o cuando el estado debe sincronizarse con otros elementos de la UI.
+
+## La regla del proyecto con React Hook Form
+
+Los componentes de formulario **siempre son controlados** cuando se usan con RHF. Esto significa que aceptan `value` y `onChange` como props, y se registran con el `Controller` de RHF.
+
+```typescript
+// ✅ componente de formulario controlado
+export interface SelectFieldProps {
+  value: string
+  onChange: (value: string) => void
+  options: SelectOption[]
+  label: string
+  error?: string
+}
+
+// Uso con React Hook Form
+<Controller
+  name="category"
+  control={control}
+  render={({ field }) => (
+    <SelectField
+      value={field.value}
+      onChange={field.onChange}
+      options={categoryOptions}
+      label="Categoría"
+      error={errors.category?.message}
+    />
+  )}
+/>
+```
+
+<Callout variant="warning">
+  No uses `register` de RHF directamente en componentes de UI personalizados. Usa siempre `Controller` y el patrón controlado. `register` está pensado para inputs HTML nativos, no para componentes con comportamiento propio.
+</Callout>
+
+## Patrón mixto: valor inicial no controlado
+
+Algunos componentes aceptan tanto un `value` externo como un estado interno como fallback. Esto es el patrón "uncontrolled with initial value":
+
+```typescript
+export interface RatingProps {
+  value?: number        // si se pasa, el componente es controlado
+  defaultValue?: number // si no se pasa value, usa este como estado inicial
+  onChange?: (value: number) => void
+}
+```
+
+Úsalo con cuidado. Mezclar ambos patrones en un mismo componente complica el comportamiento esperado. Cuando tengas duda, opta por controlado.

--- a/src/content/docs/componentes/controller-hook.mdx
+++ b/src/content/docs/componentes/controller-hook.mdx
@@ -1,0 +1,124 @@
+---
+title: El controller hook
+description: Patrón useController — separar lógica de renderizado
+section: Componentes
+order: 13
+---
+
+# El controller hook
+
+El controller hook es el corazón del componente. Mientras `index.tsx` sabe *cómo se ve*, el controller hook sabe *cómo funciona*. El componente es "tonto"; el hook es "inteligente".
+
+## Naming
+
+```
+useController[NombreDelComponente]
+```
+
+Ejemplos: `useControllerSidebar`, `useControllerCounter`, `useControllerSearchInput`.
+
+El prefijo `useController` distingue estos hooks de los hooks de datos (`useUsers`, `useAuth`) y de los hooks de utilidad (`useDebounce`, `useLocalStorage`).
+
+## Qué va en el hook
+
+**Estado local**
+```typescript
+const [isOpen, setIsOpen] = useState(false)
+const [query, setQuery] = useState('')
+```
+
+**Efectos y sincronización**
+```typescript
+useEffect(() => {
+  if (autoFocus && inputRef.current) {
+    inputRef.current.focus()
+  }
+}, [autoFocus])
+```
+
+**Handlers de eventos**
+```typescript
+const handleKeyDown = useCallback((e: KeyboardEvent) => {
+  if (e.key === 'Escape') setIsOpen(false)
+}, [])
+```
+
+**Transformaciones de datos**
+```typescript
+const filteredItems = useMemo(
+  () => items.filter(item => item.label.toLowerCase().includes(query.toLowerCase())),
+  [items, query]
+)
+```
+
+**Lógica derivada**
+```typescript
+const isEmpty = filteredItems.length === 0
+const hasSelection = selectedIds.size > 0
+```
+
+## Qué NO va en el hook
+
+- JSX de ningún tipo.
+- Clases CSS o nombres de variantes visuales (eso es lógica de presentación).
+- Lógica que solo existe para decidir qué color mostrar.
+- Llamadas directas a APIs o fetching de datos — eso va en hooks de datos separados.
+
+```typescript
+// ❌ no hagas esto en el controller hook
+const buttonClass = isActive ? 'bg-blue-500' : 'bg-gray-200'
+return { buttonClass }
+
+// ✅ en cambio, retorna el estado y deja que el renderizado decida
+return { isActive }
+```
+
+## La regla del contrato
+
+El hook recibe exactamente los mismos datos que el componente recibe del padre (o un subconjunto), y retorna exactamente lo que el JSX necesita — ni más ni menos.
+
+```typescript
+// ✅ el hook recibe los props del componente (con defaults aplicados)
+export const useControllerCounter = ({
+  initialValue,
+  min,
+  max,
+  onChange,
+}: UseControllerCounterParams): UseControllerCounterReturn => {
+  // ...
+  return {
+    count,          // el renderizado lo muestra
+    canDecrement,   // el renderizado deshabilita el botón
+    canIncrement,
+    handleIncrement,
+    handleDecrement,
+    handleReset,
+  }
+}
+```
+
+Si el hook empieza a retornar cosas que el renderizado nunca usa, algo está mal.
+
+<Callout variant="warning">
+  Si el hook supera ~100 líneas o tiene más de 5-6 `useState` no relacionados, es una señal de que el componente debe dividirse. El hook refleja la complejidad del componente — si el hook es grande, el componente es demasiado grande.
+</Callout>
+
+## Hooks de UI vs. hooks de datos
+
+| Hook de UI (`useControllerX`) | Hook de datos (`useX`) |
+|-------------------------------|------------------------|
+| Maneja estado visual y handlers | Maneja fetching, cache, mutaciones |
+| Vive en la carpeta del componente | Vive en `src/hooks/` o `src/lib/` |
+| Solo lo usa su componente | Puede usarse en múltiples lugares |
+| No llama APIs directamente | Llama APIs, usa SWR/React Query |
+
+```typescript
+// en el controller hook: consume el hook de datos
+const { data: users, isLoading } = useUsers()
+
+// lógica de UI sobre los datos
+const filteredUsers = useMemo(
+  () => users?.filter(u => u.role === selectedRole) ?? [],
+  [users, selectedRole]
+)
+```

--- a/src/content/docs/componentes/cuando-dividir-un-componente.mdx
+++ b/src/content/docs/componentes/cuando-dividir-un-componente.mdx
@@ -1,0 +1,80 @@
+---
+title: Cuándo dividir un componente
+description: Señales para saber cuándo extraer o agrupar componentes
+section: Componentes
+order: 14
+---
+
+# Cuándo dividir un componente
+
+Dividir un componente no siempre mejora el código. La pregunta correcta no es "¿puede separarse?" sino "¿tiene sentido conceptual propio?".
+
+## Señales de que SÍ debe dividirse
+
+**Más de una responsabilidad visible**
+
+Si el JSX de `index.tsx` describe dos cosas distintas — por ejemplo, un formulario de búsqueda Y una lista de resultados — probablemente son dos componentes.
+
+```
+// 🟡 sospechoso: ¿esto es un SearchInput o un SearchPanel?
+return (
+  <div>
+    <input ... />       {/* lógica de búsqueda */}
+    <ul>                {/* lógica de resultados */}
+      {results.map(...)}
+    </ul>
+    <Pagination ... />  {/* lógica de paginación */}
+  </div>
+)
+```
+
+**El JSX supera ~80 líneas**
+
+Es una heurística, no una regla absoluta. Pero si el archivo es difícil de leer de un vistazo, el componente probablemente hace demasiado.
+
+**Lógica condicional compleja y repetida**
+
+Si aparece el mismo bloque `if/else` en más de un lugar dentro del JSX, esa condición debería vivir en un componente propio.
+
+**Más de 2-3 `useState` sin relación entre sí**
+
+```typescript
+// 🟡 señal de alerta: estos estados no están relacionados
+const [isMenuOpen, setIsMenuOpen] = useState(false)
+const [formData, setFormData] = useState({ name: '', email: '' })
+const [uploadProgress, setUploadProgress] = useState(0)
+```
+
+Si el hook maneja estado de un menú, un formulario y una subida de archivo al mismo tiempo, hay tres componentes mezclados.
+
+**Se reutiliza en más de un lugar**
+
+Si copias y pegas JSX entre componentes, extrae lo que se repite. El criterio de reutilización es válido cuando el código que se repite también tiene comportamiento propio.
+
+## Señales de que NO debe dividirse
+
+**Solo para evitar repetición sin lógica propia**
+
+Crear un componente `<Label>` que solo renderiza `<label className="text-sm font-medium">` no aporta nada que una clase de Tailwind no resuelva. La abstracción prematura crea indirección sin beneficio.
+
+**Si el "componente" no tiene props propias**
+
+Un componente que siempre renderiza lo mismo y no acepta datos externos es un fragmento de JSX, no un componente.
+
+**Si la división complica más que simplifica**
+
+Si para extraer el componente necesitas pasar 6 props "hacia arriba" al padre, la abstracción está en el lugar equivocado. Revisa si la lógica también debe moverse.
+
+## Cómo decidir en la práctica
+
+Hazte estas preguntas antes de dividir:
+
+1. ¿Tiene un nombre claro que describa exactamente lo que hace?
+2. ¿Tiene props propias que lo hagan reutilizable o configurable?
+3. ¿Si lo extraigo, el componente padre se lee mejor?
+
+Si las tres respuestas son sí, divide. Si no, espera a que la necesidad sea real.
+
+<Callout variant="info">
+  La regla de oro: extrae cuando tengas evidencia de que la separación mejora la legibilidad o la reutilización, no por anticipar futuros cambios. YAGNI aplica a los componentes igual que al código.
+</Callout>

--- a/src/content/docs/componentes/estructura-de-un-componente.mdx
+++ b/src/content/docs/componentes/estructura-de-un-componente.mdx
@@ -1,0 +1,145 @@
+---
+title: Estructura de un componente
+description: Cómo organizar los archivos de un componente
+section: Componentes
+order: 11
+---
+
+# Estructura de un componente
+
+Cada componente vive en su propia carpeta con exactamente tres archivos:
+
+```
+MyComponent/
+├── index.tsx                    ← solo renderizado, sin lógica
+├── types.ts                     ← interfaces, props, tipos locales
+└── useControllerMyComponent.ts  ← todo el estado y lógica de negocio
+```
+
+## Reglas
+
+- `index.tsx` solo contiene JSX y la llamada al hook del controller. Sin `useState`, sin `useEffect`, sin lógica condicional de negocio.
+- `types.ts` exporta todas las interfaces del componente. Nada se define inline en `index.tsx`.
+- El hook `useController[NombreComponente]` encapsula: estado local, efectos, handlers, lógica de negocio. Retorna exactamente lo que el renderizado necesita.
+
+<Callout variant="tip">
+  El retorno del hook debe tiparse explícitamente siempre. Si no está tipado, el consumidor no sabe qué esperar sin leer la implementación.
+</Callout>
+
+## Ejemplo: Counter
+
+El ejemplo canónico del proyecto es un `Counter` con valor mínimo, máximo y callback de cambio.
+
+### types.ts
+
+```typescript
+export interface CounterProps {
+  initialValue?: number
+  min?: number
+  max?: number
+  onChange?: (value: number) => void
+}
+
+export interface UseControllerCounterParams {
+  initialValue: number
+  min: number
+  max: number
+  onChange?: (value: number) => void
+}
+
+export interface UseControllerCounterReturn {
+  count: number
+  canDecrement: boolean
+  canIncrement: boolean
+  handleIncrement: () => void
+  handleDecrement: () => void
+  handleReset: () => void
+}
+```
+
+### useControllerCounter.ts
+
+```typescript
+import { useState, useCallback } from 'react'
+import type { UseControllerCounterParams, UseControllerCounterReturn } from './types'
+
+export const useControllerCounter = ({
+  initialValue,
+  min,
+  max,
+  onChange,
+}: UseControllerCounterParams): UseControllerCounterReturn => {
+  const [count, setCount] = useState(initialValue)
+
+  const handleIncrement = useCallback(() => {
+    setCount(prev => {
+      const next = Math.min(prev + 1, max)
+      onChange?.(next)
+      return next
+    })
+  }, [max, onChange])
+
+  const handleDecrement = useCallback(() => {
+    setCount(prev => {
+      const next = Math.max(prev - 1, min)
+      onChange?.(next)
+      return next
+    })
+  }, [min, onChange])
+
+  const handleReset = useCallback(() => {
+    setCount(initialValue)
+    onChange?.(initialValue)
+  }, [initialValue, onChange])
+
+  return {
+    count,
+    canDecrement: count > min,
+    canIncrement: count < max,
+    handleIncrement,
+    handleDecrement,
+    handleReset,
+  }
+}
+```
+
+### index.tsx
+
+```typescript
+import type { JSX } from 'react'
+import type { CounterProps } from './types'
+import { useControllerCounter } from './useControllerCounter'
+
+export const Counter = ({
+  initialValue = 0,
+  min = 0,
+  max = 100,
+  onChange,
+}: CounterProps): JSX.Element => {
+  const {
+    count,
+    canDecrement,
+    canIncrement,
+    handleIncrement,
+    handleDecrement,
+    handleReset,
+  } = useControllerCounter({ initialValue, min, max, onChange })
+
+  return (
+    <div className="flex items-center gap-2">
+      <button onClick={handleDecrement} disabled={!canDecrement}>−</button>
+      <span>{count}</span>
+      <button onClick={handleIncrement} disabled={!canIncrement}>+</button>
+      <button onClick={handleReset}>Reset</button>
+    </div>
+  )
+}
+```
+
+## ¿Por qué no `React.FC`?
+
+El tipo `JSX.Element` como retorno explícito es preferido sobre `React.FC<Props>` porque:
+
+- No agrega `children` implícito al tipo de las props.
+- Es más preciso: documenta que el componente siempre retorna un elemento.
+- Es la convención actual de React — `React.FC` fue popular pero se aleja del modelo de funciones puras.

--- a/src/content/docs/componentes/introduccion.mdx
+++ b/src/content/docs/componentes/introduccion.mdx
@@ -1,0 +1,36 @@
+---
+title: Componentes
+description: Estándares y convenciones para crear componentes en Sanghel Playbook
+section: Componentes
+order: 10
+---
+
+# Componentes
+
+Todos los componentes del proyecto siguen un único principio rector: **separación de responsabilidades**. El renderizado y la lógica son preocupaciones distintas y deben vivir en archivos distintos.
+
+## Filosofía
+
+Un componente de React tiene dos trabajos: decidir qué mostrar y cuándo mostrarlo. Cuando ambas cosas conviven en el mismo archivo, el código se vuelve difícil de leer, probar y mantener.
+
+La solución es dividir cada componente en tres capas:
+
+- **Renderizado** (`index.tsx`): sabe *cómo* se ve la interfaz, no *por qué*.
+- **Lógica** (`useController[Nombre].ts`): sabe *qué* datos necesita el renderizado y *cómo* obtenerlos.
+- **Tipos** (`types.ts`): describe *qué forma* tienen los datos que fluyen entre las capas.
+
+Con esta separación, cambiar el diseño visual no toca la lógica, y cambiar la lógica no toca el JSX. Cada archivo tiene una razón única para cambiar.
+
+## Lo que encontrarás en esta sección
+
+| Documento | Cubre |
+|-----------|-------|
+| [Estructura de un componente](/docs/componentes/estructura-de-un-componente) | Cómo organizar los tres archivos y el ejemplo canónico `Counter` |
+| [Tipado de props](/docs/componentes/tipado-de-props) | Convenciones TypeScript: `interface` vs `type`, naming de hooks, `JSX.Element` |
+| [El controller hook](/docs/componentes/controller-hook) | Qué entra y sale del hook, qué nunca debe ir ahí |
+| [Cuándo dividir](/docs/componentes/cuando-dividir-un-componente) | Señales de que un componente está pidiendo ser partido |
+| [Controlado vs no controlado](/docs/componentes/controlado-vs-no-controlado) | Cuándo usar cada patrón y la regla del proyecto con RHF |
+
+<Callout variant="info">
+  Estos estándares aplican a todos los componentes de UI del proyecto. Los hooks de datos (que llaman a APIs o stores) siguen convenciones distintas documentadas en la sección **Hooks**.
+</Callout>

--- a/src/content/docs/componentes/tipado-de-props.mdx
+++ b/src/content/docs/componentes/tipado-de-props.mdx
@@ -1,0 +1,108 @@
+---
+title: Tipado de props
+description: Convenciones de TypeScript para props, hooks y tipos locales
+section: Componentes
+order: 12
+---
+
+# Tipado de props
+
+TypeScript es una herramienta de documentación tanto como de seguridad. Los tipos bien escritos hacen que el componente sea autoexplicativo sin necesidad de comentarios.
+
+## Reglas
+
+**Usa `interface`, no `type`, para props de componentes.**
+
+```typescript
+// ✅ correcto
+export interface ButtonProps {
+  label: string
+  onClick: () => void
+  disabled?: boolean
+}
+
+// ❌ evitar para props de componentes
+export type ButtonProps = {
+  label: string
+  onClick: () => void
+  disabled?: boolean
+}
+```
+
+`interface` es extendible y produce mensajes de error más legibles. Usa `type` para uniones, intersecciones o aliases de tipos primitivos.
+
+**Tipado explícito del retorno del hook.**
+
+El retorno del controller hook siempre lleva un tipo explícito. Nunca confíes en la inferencia aquí:
+
+```typescript
+// ✅ correcto — el consumidor sabe exactamente qué esperar
+export const useControllerCounter = (
+  params: UseControllerCounterParams
+): UseControllerCounterReturn => { ... }
+
+// ❌ evitar — la inferencia se rompe si la implementación cambia
+export const useControllerCounter = (params: UseControllerCounterParams) => { ... }
+```
+
+**Tres interfaces separadas por componente.**
+
+Cada componente necesita al menos tres interfaces bien separadas:
+
+```typescript
+// Props del componente (lo que recibe desde el padre)
+export interface CounterProps { ... }
+
+// Params del hook (generalmente igual a CounterProps con defaults aplicados)
+export interface UseControllerCounterParams { ... }
+
+// Retorno del hook (lo que el renderizado consume)
+export interface UseControllerCounterReturn { ... }
+```
+
+**Retorno del componente tipado como `JSX.Element`.**
+
+```typescript
+export const Counter = (props: CounterProps): JSX.Element => { ... }
+```
+
+Nunca `React.FC`, nunca sin anotar el retorno.
+
+## Naming convention
+
+| Elemento | Patrón | Ejemplo |
+|----------|--------|---------|
+| Props del componente | `[Nombre]Props` | `CounterProps` |
+| Params del hook | `UseController[Nombre]Params` | `UseControllerCounterParams` |
+| Retorno del hook | `UseController[Nombre]Return` | `UseControllerCounterReturn` |
+
+## PropsTable como documentación viva
+
+El componente `PropsTable` permite documentar props directamente en MDX. Las siguientes son las props del `Counter` de ejemplo:
+
+**CounterProps**
+
+| Prop | Tipo | Requerido | Default | Descripción |
+|------|------|-----------|---------|-------------|
+| `initialValue` | `number` | No | `0` | Valor inicial del contador |
+| `min` | `number` | No | `0` | Valor mínimo permitido |
+| `max` | `number` | No | `100` | Valor máximo permitido |
+| `onChange` | `(value: number) => void` | No | — | Callback llamado con el nuevo valor |
+
+<Callout variant="tip">
+  Si `UseControllerParams` y `ComponentProps` son idénticos, unifícalos en una sola interface y reutilízala. Solo sepáralos cuando el hook necesite los valores con defaults ya aplicados.
+</Callout>
+
+## Tipos locales vs. exportados
+
+No todo tipo en `types.ts` debe exportarse. Si un tipo solo se usa internamente en el hook, defínelo local al archivo. Solo exporta lo que el consumidor del componente necesita conocer.
+
+```typescript
+// types.ts
+
+// exportado — el padre lo necesita para pasar props
+export interface CounterProps { ... }
+
+// local — solo lo necesita el hook
+type CounterAction = 'increment' | 'decrement' | 'reset'
+```


### PR DESCRIPTION
## Summary
- 6 documentos MDX en `src/content/docs/componentes/`
- Cubre: filosofía de separación, estructura de archivos, tipado TypeScript, patrón controller hook, cuándo dividir, controlado vs no controlado
- Ejemplo canónico `Counter` completo con los tres archivos
- Callouts contextuales en los puntos críticos

## Test Plan
- [x] `pnpm lint` sin errores
- [x] `pnpm build` exitoso — 11 páginas prerendered (7 docs + home + 404)
- [x] Sidebar muestra sección "Componentes" con los 6 ítems
- [x] Syntax highlighting activo en todos los bloques

Closes #4