### PR TITLE
docs: forms and FormBuilder standards section

### DIFF
--- a/src/content/docs/formularios/dynamic-form-builder.mdx
+++ b/src/content/docs/formularios/dynamic-form-builder.mdx
@@ -1,0 +1,122 @@
+---
+title: DynamicFormBuilder
+description: El recorredor de campos — renderiza cada FieldDefinition en su wrapper de UI
+section: Formularios
+order: 22
+---
+
+# DynamicFormBuilder
+
+`DynamicFormBuilder` recorre un array de `FieldDefinition` y renderiza cada campo en el wrapper de UI correspondiente. No gestiona estado, no valida, no llama a APIs. Su única responsabilidad es el renderizado.
+
+## Props
+
+```typescript
+type DynamicFormBuilderProps = {
+  fields: FieldDefinition[]
+  methods: UseFormReturn
+  cols?: number
+}
+```
+
+| Prop | Tipo | Descripción |
+|------|------|-------------|
+| `fields` | `FieldDefinition[]` | Array de campos a renderizar, en el orden declarado |
+| `methods` | `UseFormReturn` | El objeto retornado por `useForm`, instanciado en el padre |
+| `cols` | `number?` | Número de columnas del grid. Por defecto, `1` |
+
+## Implementación
+
+```typescript
+import type { FieldDefinition } from '@/types/forms'
+import type { UseFormReturn } from 'react-hook-form'
+import { AppInput } from '@/components/AppInput'
+import { AppSelect } from '@/components/AppSelect'
+import { AppTextarea } from '@/components/AppTextarea'
+import { AppCheckbox } from '@/components/AppCheckbox'
+
+type Props = {
+  fields: FieldDefinition[]
+  methods: UseFormReturn
+  cols?: number
+}
+
+const fieldMap: Record<string, React.ComponentType<FieldWrapperProps>> = {
+  text: AppInput,
+  number: AppInput,
+  password: AppInput,
+  textarea: AppTextarea,
+  catalog: AppSelect,
+  select: AppSelect,
+  multiselect: AppSelect,
+  checkbox: AppCheckbox,
+  radio: AppSelect,
+}
+
+export const DynamicFormBuilder = ({ fields, methods, cols = 1 }: Props): JSX.Element => {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: `repeat(${cols}, 1fr)`, gap: '16px' }}>
+      {fields
+        .filter((field) => !field.hidden)
+        .map((field) => {
+          const Component = fieldMap[field.type]
+          if (!Component) return null
+
+          return (
+            <div
+              key={field.id}
+              style={{ gridColumn: field.gridCols ? `span ${field.gridCols}` : undefined }}
+            >
+              <Component
+                field={field}
+                control={methods.control}
+                error={methods.formState.errors[field.name]}
+              />
+            </div>
+          )
+        })}
+    </div>
+  )
+}
+```
+
+## Qué hace y qué no hace
+
+### Hace
+- Filtra los campos marcados como `hidden`
+- Selecciona el wrapper de UI según `field.type`
+- Construye el grid con `cols` y `field.gridCols`
+- Pasa `control` y `error` a cada wrapper
+
+### No hace
+- No instancia `useForm`
+- No contiene lógica de validación
+- No llama a APIs
+- No maneja el submit
+
+<Callout variant="warning">
+  Si necesitas un tipo de campo que no está en `fieldMap`, agrega el wrapper en el mapa — no pongas lógica condicional dentro del JSX del builder.
+</Callout>
+
+## Uso
+
+```typescript
+<DynamicFormBuilder
+  fields={loginFormFields}
+  methods={methods}
+  cols={2}
+/>
+```
+
+Con `cols={2}`, todos los campos ocupan 1 de 2 columnas por defecto. Un campo con `gridCols: 2` ocupa las 2 columnas completas.
+
+```typescript
+// Ejemplo: campo que ocupa el ancho completo en un grid de 2
+{
+  id: 3,
+  name: 'notes',
+  label: 'Notas',
+  type: 'textarea',
+  gridCols: 2,      // span 2 de 2 columnas
+}
+```

--- a/src/content/docs/formularios/field-definition.mdx
+++ b/src/content/docs/formularios/field-definition.mdx
@@ -1,0 +1,164 @@
+---
+title: FieldDefinition
+description: El contrato de un campo de formulario
+section: Formularios
+order: 21
+---
+
+# FieldDefinition
+
+`FieldDefinition` es el tipo central del sistema de formularios. Es el contrato que describe qué es un campo: su tipo, sus validaciones, sus opciones de UI y su posición en el grid.
+
+## Tipos de soporte
+
+```typescript
+export type CatalogueOption = {
+  value: string | number
+  label: string
+}
+
+export type FieldTypeName =
+  | 'text'
+  | 'number'
+  | 'password'
+  | 'textarea'
+  | 'catalog'
+  | 'select'
+  | 'multiselect'
+  | 'checkbox'
+  | 'radio'
+
+export type FieldUiIcon = 'mail' | 'lock' | 'user' | 'phone' | 'search'
+
+export type FieldUiHints = {
+  iconName?: FieldUiIcon
+  autoComplete?: string
+  size?: 'small' | 'middle' | 'large'
+}
+
+export type ModelName = {
+  id: number
+  name: string
+  keyword: string
+  createdAt: string
+  allowRelationships: boolean
+}
+
+export type FieldValidations = {
+  required?: boolean
+  max_chars?: number
+  min_chars?: number
+  unique?: boolean
+  to_upper_case?: boolean
+}
+```
+
+## El tipo FieldDefinition
+
+```typescript
+export type FieldDefinition = {
+  id: number
+  name: string
+  label: string
+  type: FieldTypeName
+  placeholder?: string
+  defaultValue?: string | number | boolean
+  disabled?: boolean
+  hidden?: boolean
+  gridCols?: number
+  validations?: FieldValidations
+  uiHints?: FieldUiHints
+  catalogueOptions?: CatalogueOption[]
+  modelName?: ModelName
+}
+```
+
+## Propiedades
+
+### Identidad del campo
+
+| Propiedad | Tipo | Descripción |
+|-----------|------|-------------|
+| `id` | `number` | Identificador único del campo. Se usa como `key` en el renderizado. |
+| `name` | `string` | Nombre del campo en el formulario. Debe coincidir con la clave en `defaultValues` de `useForm`. |
+| `label` | `string` | Texto visible que acompaña el input. |
+| `type` | `FieldTypeName` | Determina qué wrapper de UI se renderiza. |
+
+### Comportamiento
+
+| Propiedad | Tipo | Descripción |
+|-----------|------|-------------|
+| `placeholder` | `string?` | Texto de placeholder del input. |
+| `defaultValue` | `string \| number \| boolean?` | Valor inicial del campo. Se usa cuando no se pasa en `defaultValues` de `useForm`. |
+| `disabled` | `boolean?` | Si es `true`, el campo se renderiza deshabilitado. |
+| `hidden` | `boolean?` | Si es `true`, el campo no se renderiza. Útil para campos condicionales. |
+| `gridCols` | `number?` | Cuántas columnas ocupa el campo en el grid del formulario. Por defecto, 1. |
+
+### Validaciones
+
+`validations` recibe un objeto `FieldValidations` que `buildZodSchema` convierte en reglas de Zod.
+
+```typescript
+validations: {
+  required: true,
+  min_chars: 8,
+  max_chars: 100,
+}
+```
+
+### Hints de UI
+
+`uiHints` permite pasar información de presentación sin contaminar la lógica del campo.
+
+```typescript
+uiHints: {
+  iconName: 'mail',
+  autoComplete: 'email',
+  size: 'large',
+}
+```
+
+### Opciones de catálogo
+
+Para campos de tipo `catalog`, `select`, `multiselect` o `radio`, se usa `catalogueOptions`:
+
+```typescript
+catalogueOptions: [
+  { value: 'mx', label: 'México' },
+  { value: 'co', label: 'Colombia' },
+  { value: 'ar', label: 'Argentina' },
+]
+```
+
+Para campos de tipo `catalog` que cargan opciones desde un modelo de datos dinámico, se usa `modelName` en lugar de `catalogueOptions`.
+
+## Ejemplo completo
+
+```typescript
+// loginFormFields.ts
+import type { FieldDefinition } from '@/types/forms'
+
+export const loginFormFields: FieldDefinition[] = [
+  {
+    id: 1,
+    name: 'identifier',
+    label: 'Correo electrónico',
+    type: 'text',
+    placeholder: 'usuario@ejemplo.com',
+    uiHints: { iconName: 'mail', autoComplete: 'email' },
+    validations: { required: true },
+  },
+  {
+    id: 2,
+    name: 'password',
+    label: 'Contraseña',
+    type: 'password',
+    uiHints: { iconName: 'lock', autoComplete: 'current-password' },
+    validations: { required: true, min_chars: 8 },
+  },
+]
+```
+
+<Callout variant="tip">
+  El array de `FieldDefinition` es la única fuente de verdad del formulario. No definas validaciones en `useForm` si ya están en `validations` — `buildZodSchema` las convierte automáticamente.
+</Callout>

--- a/src/content/docs/formularios/introduccion.mdx
+++ b/src/content/docs/formularios/introduccion.mdx
@@ -1,0 +1,42 @@
+---
+title: Formularios
+description: Sistema de formularios basado en React Hook Form y FieldDefinition
+section: Formularios
+order: 20
+---
+
+# Formularios
+
+El sistema de formularios del proyecto se construye sobre **React Hook Form** y un tipo central llamado `FieldDefinition`. La filosofía es que cada capa tiene una responsabilidad única y no invade la de las demás.
+
+## Filosofía
+
+Cuatro capas completamente separadas:
+
+| Capa | Archivo | Responsabilidad |
+|------|---------|-----------------|
+| Definición del campo | `*FormFields.ts` | Declarar qué campos existen, sus tipos y validaciones |
+| Gestión de estado | `useForm` (en el padre) | Estado del formulario, errores, submit |
+| Renderizado de campos | `DynamicFormBuilder` | Recorrer los campos y delegar a los wrappers |
+| Componente de UI | `AppInput`, `AppSelect`... | Renderizar el campo y conectarlo a RHF |
+
+### Reglas que no se rompen
+
+- **El FormBuilder no sabe qué componentes de UI usa.** Elige el wrapper según el `type` del campo, pero no importa los componentes directamente en la lógica de negocio.
+- **El submit siempre ocurre en el padre.** El padre conoce el contexto: qué API llamar, qué hacer después del éxito, qué errores mostrar.
+- **El FormBuilder es un recorredor de campos, no un gestor de estado.** `useForm` se instancia en el padre y se pasa hacia abajo.
+- **Los componentes de UI son wrappers delgados.** Reciben `name` y `control` de RHF, renderizan el componente de UI y conectan los errores.
+
+## Lo que encontrarás en esta sección
+
+| Documento | Cubre |
+|-----------|-------|
+| [FieldDefinition](/docs/formularios/field-definition) | El tipo completo de un campo: propiedades, validaciones, hints de UI |
+| [DynamicFormBuilder](/docs/formularios/dynamic-form-builder) | Cómo recorre los campos y delega el renderizado |
+| [Wrapping de componentes UI](/docs/formularios/wrapping-componentes-ui) | El patrón `AppInput` / `AppSelect`: Controller + error display |
+| [Validación con Zod](/docs/formularios/validacion-con-zod) | `buildZodSchema`: construir el schema desde un array de `FieldDefinition` |
+| [Submit desde el padre](/docs/formularios/submit-desde-el-padre) | Por qué y cómo el submit siempre vive en el componente padre |
+
+<Callout variant="info">
+  Todos los formularios del proyecto siguen este patrón sin excepción. Un formulario que gestiona su propio submit o instancia `useForm` internamente viola la separación de responsabilidades.
+</Callout>

--- a/src/content/docs/formularios/submit-desde-el-padre.mdx
+++ b/src/content/docs/formularios/submit-desde-el-padre.mdx
@@ -1,0 +1,100 @@
+---
+title: Submit desde el padre
+description: Por qué y cómo el submit siempre vive en el componente padre
+section: Formularios
+order: 25
+---
+
+# Submit desde el padre
+
+El submit siempre ocurre en el padre. No en el `DynamicFormBuilder`, no en los wrappers de campo, no en un hook compartido. Solo en el padre.
+
+## Por qué
+
+El padre es el único que conoce el contexto completo:
+
+- Qué API llamar y con qué parámetros
+- A dónde redirigir después del éxito
+- Qué toast o notificación mostrar
+- Qué errores de servidor mapear a qué campos
+
+Si el submit viviera dentro del builder, este necesitaría conocer el contexto de negocio de cada formulario. Dejaría de ser un recorredor de campos genérico y se convertiría en un componente acoplado a cada caso de uso.
+
+## Patrón completo: formulario de login
+
+```typescript
+// LoginPage — el padre
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { buildZodSchema } from '@/lib/buildZodSchema'
+import { DynamicFormBuilder } from '@/components/DynamicFormBuilder'
+import { loginFormFields } from './loginFormFields'
+
+const schema = buildZodSchema(loginFormFields)
+type LoginFormValues = z.infer<typeof schema>
+
+export const LoginPage = (): JSX.Element => {
+  const methods = useForm<LoginFormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { identifier: '', password: '' },
+  })
+
+  const handleSubmit = methods.handleSubmit(async (data) => {
+    try {
+      await loginService(data)
+      router.push('/dashboard')
+    } catch (error) {
+      // Los errores de API se setean con setError para que aparezcan en el campo
+      methods.setError('identifier', {
+        type: 'server',
+        message: 'Credenciales incorrectas',
+      })
+    }
+  })
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <DynamicFormBuilder fields={loginFormFields} methods={methods} cols={1} />
+      <button type="submit" disabled={methods.formState.isSubmitting}>
+        {methods.formState.isSubmitting ? 'Ingresando...' : 'Iniciar sesión'}
+      </button>
+    </form>
+  )
+}
+```
+
+## Reglas
+
+| Regla | Motivo |
+|-------|--------|
+| `useForm` siempre se instancia en el padre | El padre controla el ciclo de vida del formulario |
+| `methods` se pasa al `DynamicFormBuilder` | El builder necesita `control` y `formState.errors` |
+| El `<form>` con `onSubmit` vive en el padre | El submit es responsabilidad del padre, no del builder |
+| `methods.handleSubmit` solo se llama en el padre | Garantiza que la lógica de negocio no se filtre al builder |
+| Los errores de servidor se setean con `methods.setError` | Permite mostrar errores de API en los campos específicos |
+
+## Estado durante el submit
+
+`formState.isSubmitting` es `true` mientras el handler async está en ejecución. Úsalo para deshabilitar el botón y evitar doble submit:
+
+```typescript
+<button type="submit" disabled={methods.formState.isSubmitting}>
+  {methods.formState.isSubmitting ? 'Guardando...' : 'Guardar'}
+</button>
+```
+
+## Reset después del submit
+
+Si el formulario debe limpiarse después de un submit exitoso:
+
+```typescript
+const handleSubmit = methods.handleSubmit(async (data) => {
+  await createRecord(data)
+  methods.reset()
+})
+```
+
+<Callout variant="warning">
+  Nunca llames `methods.handleSubmit` dentro del `DynamicFormBuilder` ni de los wrappers de campo. Si lo necesitas en un lugar distinto al padre, es una señal de que la separación de responsabilidades está rota.
+</Callout>

--- a/src/content/docs/formularios/validacion-con-zod.mdx
+++ b/src/content/docs/formularios/validacion-con-zod.mdx
@@ -1,0 +1,126 @@
+---
+title: Validación con Zod
+description: buildZodSchema — construir un schema de validación desde FieldDefinition
+section: Formularios
+order: 24
+---
+
+# Validación con Zod
+
+La validación del formulario se genera automáticamente desde el array de `FieldDefinition`. La función `buildZodSchema` recorre los campos, lee sus `validations` y construye un schema de Zod. Esto garantiza que la validación y la definición del campo estén siempre sincronizadas.
+
+## buildZodSchema
+
+```typescript
+import { z } from 'zod'
+import type { FieldDefinition } from '@/types/forms'
+
+export function buildZodSchema(fields: FieldDefinition[]): z.ZodObject<z.ZodRawShape> {
+  const shape: z.ZodRawShape = {}
+
+  for (const field of fields) {
+    const { name, validations } = field
+
+    if (!validations) {
+      shape[name] = z.string().optional()
+      continue
+    }
+
+    let schema: z.ZodTypeAny = z.string()
+
+    if (validations.max_chars) {
+      schema = (schema as z.ZodString).max(
+        validations.max_chars,
+        `Máximo ${validations.max_chars} caracteres`
+      )
+    }
+
+    if (validations.min_chars) {
+      schema = (schema as z.ZodString).min(
+        validations.min_chars,
+        `Mínimo ${validations.min_chars} caracteres`
+      )
+    }
+
+    if (!validations.required) {
+      schema = schema.optional()
+    } else {
+      schema = (schema as z.ZodString).min(1, `${field.label} es requerido`)
+    }
+
+    shape[name] = schema
+  }
+
+  return z.object(shape)
+}
+```
+
+## Cómo funciona
+
+Para cada campo en `fields`:
+
+1. Si no tiene `validations`, se registra como `z.string().optional()`.
+2. Si tiene `max_chars`, aplica `.max()` con mensaje de error.
+3. Si tiene `min_chars`, aplica `.min()` con mensaje de error.
+4. Si `required` es `false` o no está definido, marca el campo como `.optional()`.
+5. Si `required` es `true`, aplica `.min(1)` para rechazar strings vacíos.
+
+## Conectarlo a useForm con zodResolver
+
+```typescript
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { buildZodSchema } from '@/lib/buildZodSchema'
+import { loginFormFields } from './loginFormFields'
+
+const schema = buildZodSchema(loginFormFields)
+
+const methods = useForm({
+  resolver: zodResolver(schema),
+  defaultValues: {
+    identifier: '',
+    password: '',
+  },
+})
+```
+
+`zodResolver` traduce los errores de Zod al formato que RHF expone en `formState.errors`. Los mensajes que definiste en `buildZodSchema` (`'Mínimo 8 caracteres'`) son los mismos que aparecen en `error.message` dentro de los wrappers.
+
+## Inferir el tipo de los valores del formulario
+
+Zod puede inferir el tipo TypeScript del schema generado. Úsalo para tipar `defaultValues` y el argumento del handler de submit:
+
+```typescript
+import { z } from 'zod'
+
+const schema = buildZodSchema(loginFormFields)
+type LoginFormValues = z.infer<typeof schema>
+// => { identifier: string; password: string }
+
+const handleSubmit = methods.handleSubmit(async (data: LoginFormValues) => {
+  await loginService(data)
+})
+```
+
+## Extender el schema con validaciones custom
+
+Si un campo necesita una validación que `FieldValidations` no cubre (formato de email, confirmación de contraseña, etc.), extiende el schema después de crearlo:
+
+```typescript
+const baseSchema = buildZodSchema(fields)
+
+const schema = baseSchema.extend({
+  email: z.string().email('Formato de email inválido'),
+  passwordConfirm: z.string(),
+}).refine(
+  (data) => data.password === data.passwordConfirm,
+  {
+    message: 'Las contraseñas no coinciden',
+    path: ['passwordConfirm'],
+  }
+)
+```
+
+<Callout variant="warning">
+  No pongas validaciones en `useForm` directamente (`rules` en `Controller`). Toda la validación debe vivir en el schema de Zod para que haya una sola fuente de verdad.
+</Callout>

--- a/src/content/docs/formularios/wrapping-componentes-ui.mdx
+++ b/src/content/docs/formularios/wrapping-componentes-ui.mdx
@@ -1,0 +1,138 @@
+---
+title: Wrapping de componentes UI
+description: El patrón AppInput / AppSelect — conectar componentes de UI a React Hook Form
+section: Formularios
+order: 23
+---
+
+# Wrapping de componentes UI
+
+Los componentes como `AppInput`, `AppSelect` o `AppTextarea` son wrappers delgados. Toman un componente de UI (Ant Design, Radix, etc.) y lo conectan a **React Hook Form** vía `Controller`. Son el puente entre el sistema de formularios y la librería de UI.
+
+## Props del wrapper
+
+```typescript
+type FieldWrapperProps = {
+  field: FieldDefinition
+  control: Control
+  error?: FieldError
+}
+```
+
+Todos los wrappers reciben la misma interfaz: el campo (`field`), el control de RHF (`control`) y el error si lo hay.
+
+## El patrón: Controller
+
+El wrapper usa `Controller` de RHF para registrar el campo y conectar el valor:
+
+```typescript
+import { Controller } from 'react-hook-form'
+import type { Control, FieldError } from 'react-hook-form'
+import type { FieldDefinition } from '@/types/forms'
+
+type Props = {
+  field: FieldDefinition
+  control: Control
+  error?: FieldError
+}
+
+export const AppInput = ({ field, control, error }: Props): JSX.Element => {
+  return (
+    <Controller
+      name={field.name}
+      control={control}
+      render={({ field: rhfField }) => (
+        <div>
+          <label htmlFor={field.name}>{field.label}</label>
+          <input
+            {...rhfField}
+            id={field.name}
+            type={field.type === 'password' ? 'password' : 'text'}
+            placeholder={field.placeholder}
+            disabled={field.disabled}
+            autoComplete={field.uiHints?.autoComplete}
+          />
+          {error && <span role="alert">{error.message}</span>}
+        </div>
+      )}
+    />
+  )
+}
+```
+
+## Por qué Controller y no register
+
+`register` funciona bien para inputs nativos HTML, pero los componentes de UI de librerías (Ant Design, Radix, etc.) exponen interfaces no estándar — no tienen los eventos `onChange`/`onBlur` que `register` espera. `Controller` resuelve esto: proporciona `field.onChange`, `field.value` y `field.onBlur` que se pueden pasar al componente independientemente de su API.
+
+```typescript
+// Con una librería de UI que espera value y onChange propios
+<Controller
+  name={field.name}
+  control={control}
+  render={({ field: rhfField }) => (
+    <Select
+      value={rhfField.value}
+      onChange={rhfField.onChange}
+      onBlur={rhfField.onBlur}
+      options={field.catalogueOptions}
+    />
+  )}
+/>
+```
+
+## Error display
+
+El error viene de `methods.formState.errors[field.name]` en el `DynamicFormBuilder` y se pasa como prop `error`. El wrapper decide cómo mostrarlo. El estándar del proyecto es mostrarlo debajo del input con `role="alert"` para accesibilidad.
+
+```typescript
+{error && (
+  <span role="alert" className="field-error">
+    {error.message}
+  </span>
+)}
+```
+
+## AppSelect: opciones dinámicas
+
+Cuando el campo es de tipo `catalog`, `select` o `multiselect`, el wrapper accede a `field.catalogueOptions`:
+
+```typescript
+export const AppSelect = ({ field, control, error }: Props): JSX.Element => {
+  return (
+    <Controller
+      name={field.name}
+      control={control}
+      render={({ field: rhfField }) => (
+        <div>
+          <label htmlFor={field.name}>{field.label}</label>
+          <select
+            {...rhfField}
+            id={field.name}
+            disabled={field.disabled}
+            multiple={field.type === 'multiselect'}
+          >
+            <option value="">-- Selecciona --</option>
+            {field.catalogueOptions?.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          {error && <span role="alert">{error.message}</span>}
+        </div>
+      )}
+    />
+  )
+}
+```
+
+## Reglas del wrapper
+
+- Solo hace renderizado: no tiene estado propio, no llama a APIs.
+- Recibe `control`, no `methods` completo — el wrapper no necesita acceso a `handleSubmit`, `reset` ni `setError`.
+- El error lo muestra, no lo genera. La validación ocurre en el schema de Zod.
+- Nunca instancia `useForm`.
+
+<Callout variant="tip">
+  Si un wrapper necesita lógica más compleja (cargar opciones async, transformar el valor antes de pasarlo a RHF), extrae esa lógica a un hook `useControllerAppSelect`. El wrapper sigue siendo solo renderizado.
+</Callout>


### PR DESCRIPTION
## Resumen
Sección completa de Formularios: documenta el sistema basado en React Hook Form y FieldDefinition, siguiendo la filosofía de separación de responsabilidades del proyecto.

## Tareas Completadas
- [x] Introducción a formularios — filosofía y 4 capas (#8)
- [x] FieldDefinition — tipo completo con propiedades y ejemplo (#10)
- [x] DynamicFormBuilder — fieldMap, grid y responsabilidades (#12)
- [x] Wrapping de componentes UI — patrón Controller con AppInput/AppSelect (#14)
- [x] Validación con Zod — buildZodSchema, zodResolver e inferencia de tipos (#16)
- [x] Submit desde el padre — patrón completo con setError e isSubmitting (#18)

## Testing
- ✅ Build exitoso (17 páginas estáticas generadas)
- ✅ Los 6 documentos se renderizan correctamente
- ✅ Sin errores de TypeScript
- ✅ Sidebar muestra la sección Formularios con todos los ítems

## Next Steps
Siguiente fase a desarrollar según el plan del proyecto.

Closes #7