### PR TITLE
feat: DocNavigation — anterior/siguiente al pie del doc

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -1,7 +1,8 @@
 import { notFound } from 'next/navigation'
-import { getDocBySlug, getAllDocs } from '@/lib/docs'
+import { getDocBySlug, getAllDocs, getAdjacentDocs } from '@/lib/docs'
 import { renderMDX, extractToc } from '@/lib/mdx'
 import { TableOfContents } from '@/components/TableOfContents'
+import { DocNavigation } from '@/components/DocNavigation'
 import type { Metadata } from 'next'
 
 interface PageProps {
@@ -36,6 +37,7 @@ export default async function DocPage({ params }: PageProps) {
 
   const { content } = await renderMDX(doc.content)
   const toc = extractToc(doc.content)
+  const { prev, next } = getAdjacentDocs(slug)
 
   return (
     <div className="flex gap-8 w-full max-w-5xl mx-auto px-6 py-10">
@@ -53,6 +55,7 @@ export default async function DocPage({ params }: PageProps) {
         <div className="prose prose-zinc dark:prose-invert max-w-none prose-headings:scroll-mt-20 prose-code:before:content-none prose-code:after:content-none">
           {content}
         </div>
+        <DocNavigation prev={prev} next={next} />
       </article>
 
       <TableOfContents items={toc} />

--- a/src/components/DocNavigation/index.tsx
+++ b/src/components/DocNavigation/index.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link'
+import type { DocNavigationProps } from './types'
+
+export function DocNavigation({ prev, next }: DocNavigationProps) {
+  if (!prev && !next) return null
+
+  return (
+    <nav
+      className="mt-16 pt-6 border-t border-zinc-200 dark:border-zinc-800 flex items-center justify-between gap-4"
+      aria-label="Navegación de documentos"
+    >
+      {prev ? (
+        <Link
+          href={prev.href}
+          className="group flex flex-col gap-1 rounded-lg border border-zinc-200 dark:border-zinc-800 px-4 py-3 hover:border-zinc-400 dark:hover:border-zinc-600 transition-colors max-w-[45%]"
+        >
+          <span className="text-xs text-zinc-500 dark:text-zinc-400">← Anterior</span>
+          <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100 group-hover:text-zinc-700 dark:group-hover:text-zinc-300 transition-colors">
+            {prev.title}
+          </span>
+        </Link>
+      ) : (
+        <div />
+      )}
+
+      {next ? (
+        <Link
+          href={next.href}
+          className="group flex flex-col gap-1 items-end rounded-lg border border-zinc-200 dark:border-zinc-800 px-4 py-3 hover:border-zinc-400 dark:hover:border-zinc-600 transition-colors max-w-[45%]"
+        >
+          <span className="text-xs text-zinc-500 dark:text-zinc-400">Siguiente →</span>
+          <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100 group-hover:text-zinc-700 dark:group-hover:text-zinc-300 transition-colors text-right">
+            {next.title}
+          </span>
+        </Link>
+      ) : (
+        <div />
+      )}
+    </nav>
+  )
+}

--- a/src/components/DocNavigation/types.ts
+++ b/src/components/DocNavigation/types.ts
@@ -1,0 +1,9 @@
+export type DocLink = {
+  title: string
+  href: string
+}
+
+export type DocNavigationProps = {
+  prev: DocLink | null
+  next: DocLink | null
+}

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -57,6 +57,23 @@ export function getDocBySlug(slug: string[]): Doc | null {
   return { slug, frontmatter: data as DocFrontmatter, content }
 }
 
+export function getAdjacentDocs(slug: string[]): {
+  prev: { title: string; href: string } | null
+  next: { title: string; href: string } | null
+} {
+  const docs = getAllDocs()
+  const currentHref = `/docs/${slug.join('/')}`
+  const index = docs.findIndex((doc) => `/docs/${doc.slug.join('/')}` === currentHref)
+
+  const prev = index > 0 ? docs[index - 1] : null
+  const next = index < docs.length - 1 ? docs[index + 1] : null
+
+  return {
+    prev: prev ? { title: prev.frontmatter.title, href: `/docs/${prev.slug.join('/')}` } : null,
+    next: next ? { title: next.frontmatter.title, href: `/docs/${next.slug.join('/')}` } : null,
+  }
+}
+
 export function getNavigation(): NavSection[] {
   const files = getMdxFiles(DOCS_DIR)
   const sections: Map<string, NavItem[]> = new Map()


### PR DESCRIPTION
## Cambios
- Nuevo src/components/DocNavigation/ con index.tsx y types.ts (DocLink)
- getAdjacentDocs() en src/lib/docs.ts calcula prev/next desde getAllDocs() ordenado
- page.tsx integra <DocNavigation prev={prev} next={next} /> al pie del article
- Build pasa sin errores

Closes #26
Related to #21