### PR TITLE
feat: sitemap.ts y robots.ts

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from 'next'
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://sanghel-playbook.vercel.app'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  }
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,25 @@
+import type { MetadataRoute } from 'next'
+import { getAllDocs } from '@/lib/docs'
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://sanghel-playbook.vercel.app'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const docs = getAllDocs()
+
+  const docUrls = docs.map((doc) => ({
+    url: `${BASE_URL}/docs/${doc.slug.join('/')}`,
+    lastModified: new Date(),
+    changeFrequency: 'weekly' as const,
+    priority: 0.8,
+  }))
+
+  return [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    ...docUrls,
+  ]
+}


### PR DESCRIPTION
## Cambios
- src/app/sitemap.ts: genera /sitemap.xml dinámico desde getAllDocs(), URLs con priority y changeFrequency
- src/app/robots.ts: genera /robots.txt con allow: '/' y link al sitemap
- Ambos usan NEXT_PUBLIC_SITE_URL con fallback a sanghel-playbook.vercel.app
- Build genera /sitemap.xml y /robots.txt como rutas estáticas

Closes #30
Related to #21