### PR TITLE
chore: generateStaticParams verificado — dynamicParams=false

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -9,6 +9,8 @@ interface PageProps {
   params: Promise<{ slug: string[] }>
 }
 
+export const dynamicParams = false
+
 export async function generateStaticParams() {
   const docs = getAllDocs()
   return docs.map((doc) => ({ slug: doc.slug }))


### PR DESCRIPTION
## Cambios
- generateStaticParams ya estaba implementado desde la base del proyecto
- Añadido dynamicParams=false para garantizar 404 en slugs desconocidos en lugar de intento de renderizado dinámico
- Build genera los 13 docs correctamente (getting-started + 6 componentes + 6 formularios)

Closes #32
Related to #21