### PR TITLE
fix: pre-deploy checks — lint, TypeScript y build limpios

### DIFF
--- a/src/components/SearchModal/index.tsx
+++ b/src/components/SearchModal/index.tsx
@@ -5,7 +5,7 @@ import { useControllerSearchModal } from './useControllerSearchModal'
 import type { SearchModalProps } from './types'
 
 export function SearchModal({ docs }: SearchModalProps) {
-  const { isOpen, query, results, activeIndex, inputRef, close, setQuery, handleKeyboardNav } =
+  const { isOpen, query, results, activeIndex, inputRef, close, handleQueryChange, handleKeyboardNav } =
     useControllerSearchModal(docs)
 
   if (!isOpen) return null
@@ -37,7 +37,7 @@ export function SearchModal({ docs }: SearchModalProps) {
             ref={inputRef}
             type="text"
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
+            onChange={(e) => handleQueryChange(e.target.value)}
             onKeyDown={handleKeyboardNav}
             placeholder="Buscar documentos..."
             className="flex-1 py-4 bg-transparent text-sm text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400 outline-none"

--- a/src/components/SearchModal/useControllerSearchModal.ts
+++ b/src/components/SearchModal/useControllerSearchModal.ts
@@ -10,8 +10,7 @@ export function useControllerSearchModal(docs: SearchDoc[]) {
   const [results, setResults] = useState<SearchDoc[]>([])
   const [activeIndex, setActiveIndex] = useState(0)
   const inputRef = useRef<HTMLInputElement>(null)
-
-  const fuse = useRef(
+  const fuseRef = useRef(
     new Fuse(docs, {
       keys: ['title', 'description'],
       threshold: 0.3,
@@ -19,13 +18,22 @@ export function useControllerSearchModal(docs: SearchDoc[]) {
     })
   )
 
-  const open = useCallback(() => setIsOpen(true), [])
   const close = useCallback(() => {
     setIsOpen(false)
     setQuery('')
     setResults([])
     setActiveIndex(0)
   }, [])
+
+  function handleQueryChange(newQuery: string) {
+    setQuery(newQuery)
+    setActiveIndex(0)
+    if (!newQuery.trim()) {
+      setResults([])
+      return
+    }
+    setResults(fuseRef.current.search(newQuery).map((r) => r.item))
+  }
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -53,17 +61,6 @@ export function useControllerSearchModal(docs: SearchDoc[]) {
     }
   }, [isOpen])
 
-  useEffect(() => {
-    if (!query.trim()) {
-      setResults([])
-      setActiveIndex(0)
-      return
-    }
-    const hits = fuse.current.search(query).map((r) => r.item)
-    setResults(hits)
-    setActiveIndex(0)
-  }, [query])
-
   function handleKeyboardNav(e: React.KeyboardEvent) {
     if (e.key === 'ArrowDown') {
       e.preventDefault()
@@ -82,9 +79,8 @@ export function useControllerSearchModal(docs: SearchDoc[]) {
     results,
     activeIndex,
     inputRef,
-    open,
     close,
-    setQuery,
+    handleQueryChange,
     handleKeyboardNav,
   }
 }


### PR DESCRIPTION
## Cambios
- Corregido useControllerSearchModal: resultados derivados en handleQueryChange (event handler) en lugar de useMemo/useEffect
  - useMemo bloqueado por react-hooks/refs (no se puede leer ref.current en render)
  - useEffect bloqueado por react-hooks/set-state-in-effect
  - Event handlers sí pueden acceder a ref.current
- pnpm lint: 0 errores
- npx tsc --noEmit: 0 errores
- pnpm build: exitoso

Closes #36
Related to #35