### PR TITLE
chore: GitHub Actions CI — lint, TypeScript y build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Cambios
- Creado .github/workflows/ci.yml
- Se ejecuta en push a main y PRs contra main
- Pasos: pnpm install → pnpm lint → npx tsc --noEmit → pnpm build
- Usa pnpm/action-setup@v4 (v10) con cache de pnpm

Closes #38
Related to #35