### PR TITLE
feat: indicador visual activo en TOC con barra vertical

### DIFF
--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -15,15 +15,20 @@ export function TableOfContents({ items }: TableOfContentsProps) {
         <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
           On this page
         </p>
-        <ul className="flex flex-col gap-1.5">
+        <ul className="flex flex-col gap-1.5 border-l border-zinc-200 dark:border-zinc-800">
           {items.map((item) => (
             <li
               key={item.id}
-              style={{ paddingLeft: `${(item.level - 1) * 12}px` }}
+              style={{ paddingLeft: `${8 + (item.level - 1) * 12}px` }}
+              className={`border-l-2 -ml-px transition-colors ${
+                activeId === item.id
+                  ? 'border-zinc-900 dark:border-zinc-100'
+                  : 'border-transparent'
+              }`}
             >
               <Link
                 href={`#${item.id}`}
-                className={`text-xs transition-colors ${
+                className={`block text-xs transition-colors py-0.5 ${
                   activeId === item.id
                     ? 'text-zinc-900 dark:text-zinc-100 font-medium'
                     : 'text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100'


### PR DESCRIPTION
## Cambios
- Track base `border-l` en el `<ul>` del TOC
- Cada `<li>` tiene `border-l-2 -ml-px` que muestra la barra cuando está activo
- Transición suave `transition-colors` en borde y texto
- Soporte dark mode

## Testing
- ✅ Hacer scroll en la página → barra vertical aparece en el item activo
- ✅ TypeScript sin errores
- ✅ Funciona en light y dark mode

Closes #42
Related to #40