### PR TITLE
FASE 1: Fix TOC navigation + indicador activo

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@tailwindcss/typography": "^0.5.19",
     "fuse.js": "^7.3.0",
+    "github-slugger": "^2.0.0",
     "gray-matter": "^4.0.3",
     "next": "16.2.4",
     "next-mdx-remote": "^6.0.0",
@@ -18,6 +19,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "rehype-pretty-code": "^0.14.3",
+    "rehype-slug": "^6.0.0",
     "shiki": "^4.0.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       fuse.js:
         specifier: ^7.3.0
         version: 7.3.0
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -35,6 +38,9 @@ importers:
       rehype-pretty-code:
         specifier: ^0.14.3
         version: 0.14.3(shiki@4.0.2)
+      rehype-slug:
+        specifier: ^6.0.0
+        version: 6.0.0
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
@@ -1324,6 +1330,9 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1387,6 +1396,9 @@ packages:
 
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-heading-rank@3.0.0:
+    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
 
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
@@ -2093,6 +2105,9 @@ packages:
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
+
+  rehype-slug@6.0.0:
+    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
   remark-mdx@3.1.1:
     resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
@@ -3889,6 +3904,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  github-slugger@2.0.0: {}
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -3958,6 +3975,10 @@ snapshots:
       vfile: 6.0.3
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
+
+  hast-util-heading-rank@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
 
   hast-util-parse-selector@4.0.0:
     dependencies:
@@ -4936,6 +4957,14 @@ snapshots:
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
       - supports-color
+
+  rehype-slug@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      github-slugger: 2.0.0
+      hast-util-heading-rank: 3.0.0
+      hast-util-to-string: 3.0.1
+      unist-util-visit: 5.1.0
 
   remark-mdx@3.1.1:
     dependencies:

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,6 +20,7 @@
 html {
   height: 100%;
   -webkit-font-smoothing: antialiased;
+  scroll-behavior: smooth;
 }
 
 body {

--- a/src/components/TableOfContents/index.tsx
+++ b/src/components/TableOfContents/index.tsx
@@ -15,15 +15,20 @@ export function TableOfContents({ items }: TableOfContentsProps) {
         <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
           On this page
         </p>
-        <ul className="flex flex-col gap-1.5">
+        <ul className="flex flex-col gap-1.5 border-l border-zinc-200 dark:border-zinc-800">
           {items.map((item) => (
             <li
               key={item.id}
-              style={{ paddingLeft: `${(item.level - 1) * 12}px` }}
+              style={{ paddingLeft: `${8 + (item.level - 1) * 12}px` }}
+              className={`border-l-2 -ml-px transition-colors ${
+                activeId === item.id
+                  ? 'border-zinc-900 dark:border-zinc-100'
+                  : 'border-transparent'
+              }`}
             >
               <Link
                 href={`#${item.id}`}
-                className={`text-xs transition-colors ${
+                className={`block text-xs transition-colors py-0.5 ${
                   activeId === item.id
                     ? 'text-zinc-900 dark:text-zinc-100 font-medium'
                     : 'text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100'

--- a/src/lib/mdx.ts
+++ b/src/lib/mdx.ts
@@ -1,5 +1,7 @@
 import { compileMDX } from 'next-mdx-remote/rsc'
 import rehypePrettyCode from 'rehype-pretty-code'
+import rehypeSlug from 'rehype-slug'
+import GithubSlugger from 'github-slugger'
 import { CodeBlock } from '@/components/CodeBlock'
 import { Callout } from '@/components/Callout'
 import { PropsTable } from '@/components/PropsTable'
@@ -20,16 +22,14 @@ export interface TocItem {
 export function extractToc(rawContent: string): TocItem[] {
   const lines = rawContent.split('\n')
   const toc: TocItem[] = []
+  const slugger = new GithubSlugger()
 
   for (const line of lines) {
     const match = line.match(/^(#{1,3})\s+(.+)$/)
     if (match) {
       const level = match[1].length
       const title = match[2].trim()
-      const id = title
-        .toLowerCase()
-        .replace(/[^\w\s-]/g, '')
-        .replace(/\s+/g, '-')
+      const id = slugger.slug(title)
       toc.push({ id, title, level })
     }
   }
@@ -44,6 +44,7 @@ export async function renderMDX(source: string) {
       parseFrontmatter: true,
       mdxOptions: {
         rehypePlugins: [
+          rehypeSlug,
           [
             rehypePrettyCode,
             {


### PR DESCRIPTION
## Resumen
Corrección del bug crítico del TOC (headings sin IDs en el DOM) y mejora del indicador visual de sección activa.

## Tareas Completadas
- [x] fix: rehype-slug en MDX pipeline + extractToc con github-slugger (#43)
- [x] feat: indicador visual activo en TOC con barra vertical (#44)

## Cambios técnicos
- `rehype-slug` agrega `id` a los headings en el HTML renderizado
- `extractToc()` usa `github-slugger` para generar IDs idénticos a los del DOM
- TOC muestra barra vertical izquierda en el item activo con `border-l-2`
- `scroll-behavior: smooth` para navegación fluida

## Testing
- ✅ Build exitoso (19 páginas generadas)
- ✅ TypeScript sin errores
- ✅ Clicks en TOC navegan al heading correcto
- ✅ Scroll actualiza indicador activo en TOC

Closes #40