### PR TITLE
feat: sistema de navegación de 3 niveles (NavGroup + NavSubSection)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -23,7 +23,7 @@ export const metadata: Metadata = {
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  const sections = getNavigation()
+  const groups = getNavigation()
   const searchDocs = getAllDocs().map((doc) => ({
     title: doc.frontmatter.title,
     description: doc.frontmatter.description ?? '',
@@ -39,7 +39,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className="bg-white dark:bg-zinc-950 text-zinc-900 dark:text-zinc-50">
         <ThemeProvider>
           <div className="flex h-screen overflow-hidden">
-            <Sidebar sections={sections} />
+            <Sidebar groups={groups} />
             <div className="flex flex-1 flex-col overflow-hidden">
               <Header />
               <main className="flex-1 overflow-y-auto">

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -2,51 +2,93 @@
 
 import Link from 'next/link'
 import { useControllerSidebar } from './useControllerSidebar'
-import type { NavSection } from './types'
+import type { NavGroup } from './types'
 
 interface SidebarProps {
-  sections: NavSection[]
+  groups: NavGroup[]
 }
 
-export function Sidebar({ sections }: SidebarProps) {
-  const { mobileOpen, collapsed, isActive, toggleSection, toggleMobile, closeMobile } =
-    useControllerSidebar(sections)
+export function Sidebar({ groups }: SidebarProps) {
+  const { mobileOpen, collapsed, isActive, toggleKey, toggleMobile, closeMobile } =
+    useControllerSidebar(groups)
 
   const nav = (
     <nav className="flex flex-col gap-6 py-6 px-4">
-      {sections.map((section) => (
-        <div key={section.title}>
+      {groups.map((group) => (
+        <div key={group.title}>
+          {/* Group header */}
           <button
-            onClick={() => toggleSection(section.title)}
+            onClick={() => toggleKey(group.title)}
             className="flex w-full items-center justify-between mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 transition-colors"
           >
-            {section.title}
-            <span className="text-zinc-400">{collapsed[section.title] ? '+' : '−'}</span>
+            {group.title}
+            <span className="text-zinc-400">{collapsed[group.title] ? '+' : '−'}</span>
           </button>
 
-          {!collapsed[section.title] && (
-            <ul className="flex flex-col gap-0.5">
-              {section.items.map((item) => (
-                <li key={item.href}>
-                  <Link
-                    href={item.href}
-                    onClick={closeMobile}
-                    className={`block rounded-md px-3 py-1.5 text-sm transition-colors ${
-                      isActive(item.href)
-                        ? 'bg-zinc-900 text-white dark:bg-white dark:text-zinc-900 font-medium'
-                        : 'text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 hover:bg-zinc-100 dark:hover:bg-zinc-800'
-                    }`}
-                  >
-                    {item.title}
-                  </Link>
-                </li>
-              ))}
-            </ul>
+          {!collapsed[group.title] && (
+            <div className="flex flex-col gap-3">
+              {/* Sub-sections (depth 3) */}
+              {group.subsections.map((sub) => {
+                const subKey = `${group.title}:${sub.title}`
+                return (
+                  <div key={sub.title}>
+                    <button
+                      onClick={() => toggleKey(subKey)}
+                      className="flex w-full items-center justify-between mb-1 pl-2 text-xs font-medium text-zinc-400 dark:text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
+                    >
+                      {sub.title}
+                      <span>{collapsed[subKey] ? '+' : '−'}</span>
+                    </button>
+
+                    {!collapsed[subKey] && (
+                      <ul className="flex flex-col gap-0.5">
+                        {sub.items.map((item) => (
+                          <li key={item.href}>
+                            <Link
+                              href={item.href}
+                              onClick={closeMobile}
+                              className={`block rounded-md px-3 py-1.5 text-sm transition-colors ${
+                                isActive(item.href)
+                                  ? 'bg-zinc-900 text-white dark:bg-white dark:text-zinc-900 font-medium'
+                                  : 'text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 hover:bg-zinc-100 dark:hover:bg-zinc-800'
+                              }`}
+                            >
+                              {item.title}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                )
+              })}
+
+              {/* Direct items (depth 2) */}
+              {group.items.length > 0 && (
+                <ul className="flex flex-col gap-0.5">
+                  {group.items.map((item) => (
+                    <li key={item.href}>
+                      <Link
+                        href={item.href}
+                        onClick={closeMobile}
+                        className={`block rounded-md px-3 py-1.5 text-sm transition-colors ${
+                          isActive(item.href)
+                            ? 'bg-zinc-900 text-white dark:bg-white dark:text-zinc-900 font-medium'
+                            : 'text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 hover:bg-zinc-100 dark:hover:bg-zinc-800'
+                        }`}
+                      >
+                        {item.title}
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
           )}
         </div>
       ))}
 
-      {sections.length === 0 && (
+      {groups.length === 0 && (
         <p className="text-xs text-zinc-400 dark:text-zinc-500">No docs yet.</p>
       )}
     </nav>

--- a/src/components/Sidebar/types.ts
+++ b/src/components/Sidebar/types.ts
@@ -4,7 +4,13 @@ export interface NavItem {
   slug: string[]
 }
 
-export interface NavSection {
+export interface NavSubSection {
   title: string
   items: NavItem[]
+}
+
+export interface NavGroup {
+  title: string
+  items: NavItem[]
+  subsections: NavSubSection[]
 }

--- a/src/components/Sidebar/useControllerSidebar.ts
+++ b/src/components/Sidebar/useControllerSidebar.ts
@@ -2,9 +2,9 @@
 
 import { useState } from 'react'
 import { usePathname } from 'next/navigation'
-import type { NavSection } from './types'
+import type { NavGroup } from './types'
 
-export function useControllerSidebar(sections: NavSection[]) {
+export function useControllerSidebar(groups: NavGroup[]) {
   const pathname = usePathname()
   const [mobileOpen, setMobileOpen] = useState(false)
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({})
@@ -13,8 +13,8 @@ export function useControllerSidebar(sections: NavSection[]) {
     return pathname === href
   }
 
-  function toggleSection(title: string) {
-    setCollapsed((prev) => ({ ...prev, [title]: !prev[title] }))
+  function toggleKey(key: string) {
+    setCollapsed((prev) => ({ ...prev, [key]: !prev[key] }))
   }
 
   function toggleMobile() {
@@ -26,12 +26,12 @@ export function useControllerSidebar(sections: NavSection[]) {
   }
 
   return {
-    sections,
+    groups,
     pathname,
     mobileOpen,
     collapsed,
     isActive,
-    toggleSection,
+    toggleKey,
     toggleMobile,
     closeMobile,
   }

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 import matter from 'gray-matter'
-import type { NavSection, NavItem } from '@/components/Sidebar/types'
+import type { NavGroup, NavSubSection, NavItem } from '@/components/Sidebar/types'
 
 const DOCS_DIR = path.join(process.cwd(), 'src/content/docs')
 
@@ -74,29 +74,47 @@ export function getAdjacentDocs(slug: string[]): {
   }
 }
 
-export function getNavigation(): NavSection[] {
-  const files = getMdxFiles(DOCS_DIR)
-  const sections: Map<string, NavItem[]> = new Map()
+function formatTitle(raw: string): string {
+  return raw.charAt(0).toUpperCase() + raw.slice(1).replace(/-/g, ' ')
+}
 
-  for (const file of files) {
-    const slug = pathToSlug(file)
-    const raw = fs.readFileSync(file, 'utf-8')
-    const { data } = matter(raw)
-    const fm = data as DocFrontmatter
+export function getNavigation(): NavGroup[] {
+  const docs = getAllDocs()
+  const groups: Map<string, NavGroup> = new Map()
 
-    const rawSection = slug.length > 1 ? slug[0] : 'General'
-    const sectionTitle =
-      rawSection.charAt(0).toUpperCase() + rawSection.slice(1).replace(/-/g, ' ')
-
+  for (const doc of docs) {
+    const { slug, frontmatter: fm } = doc
     const item: NavItem = {
       title: fm.title ?? slug[slug.length - 1].replace(/-/g, ' '),
       href: `/docs/${slug.join('/')}`,
       slug,
     }
 
-    const existing = sections.get(sectionTitle) ?? []
-    sections.set(sectionTitle, [...existing, item])
+    if (slug.length === 1) {
+      // Root file → "General" group, direct item
+      const group = groups.get('General') ?? { title: 'General', items: [], subsections: [] }
+      group.items.push(item)
+      groups.set('General', group)
+    } else if (slug.length === 2) {
+      // tech/file → NavGroup from slug[0], direct item
+      const groupTitle = formatTitle(slug[0])
+      const group = groups.get(groupTitle) ?? { title: groupTitle, items: [], subsections: [] }
+      group.items.push(item)
+      groups.set(groupTitle, group)
+    } else {
+      // tech/topic/file → NavGroup from slug[0], NavSubSection from slug[1]
+      const groupTitle = formatTitle(slug[0])
+      const subTitle = formatTitle(slug[1])
+      const group = groups.get(groupTitle) ?? { title: groupTitle, items: [], subsections: [] }
+      let sub = group.subsections.find((s) => s.title === subTitle)
+      if (!sub) {
+        sub = { title: subTitle, items: [] }
+        group.subsections.push(sub)
+      }
+      sub.items.push(item)
+      groups.set(groupTitle, group)
+    }
   }
 
-  return Array.from(sections.entries()).map(([title, items]) => ({ title, items }))
+  return Array.from(groups.values())
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { NavItem, NavSection } from '@/components/Sidebar/types'
+export type { NavItem, NavSubSection, NavGroup } from '@/components/Sidebar/types'
 export type { DocFrontmatter, Doc } from '@/lib/docs'
 export type { TocItem } from '@/lib/mdx'
 export type { CalloutVariant, CalloutProps } from '@/components/Callout/types'


### PR DESCRIPTION
## Cambios
- `NavSection` reemplazado por `NavGroup` (contiene `items` directos + `subsections: NavSubSection[]`)
- `getNavigation()` clasifica docs por profundidad de carpeta: depth-1 → General, depth-2 → grupo plano, depth-3 → grupo con subsección
- Sidebar renderiza jerarquía: Tecnología (toggle) → Sub-sección (toggle) → Artículo (link)
- `useControllerSidebar` usa `toggleKey(key)` con clave compuesta `Grupo:SubSección`
- `src/types/index.ts` actualizado para exportar nuevos tipos

## Testing
- ✅ TypeScript sin errores
- ✅ Estructura lista para recibir content `react/componentes/` y `nextjs/`

Closes #47
Related to #46