### PR TITLE
feat: DownloadButton para descargar doc como .md (reglas para agente AI)

### DIFF
--- a/src/app/docs/[...slug]/page.tsx
+++ b/src/app/docs/[...slug]/page.tsx
@@ -3,6 +3,7 @@ import { getDocBySlug, getAllDocs, getAdjacentDocs } from '@/lib/docs'
 import { renderMDX, extractToc } from '@/lib/mdx'
 import { TableOfContents } from '@/components/TableOfContents'
 import { DocNavigation } from '@/components/DocNavigation'
+import { DownloadButton } from '@/components/DownloadButton'
 import type { Metadata } from 'next'
 
 interface PageProps {
@@ -45,9 +46,17 @@ export default async function DocPage({ params }: PageProps) {
     <div className="flex gap-8 w-full max-w-5xl mx-auto px-6 py-10">
       <article className="flex-1 min-w-0">
         <header className="mb-8">
-          <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
-            {doc.frontmatter.title}
-          </h1>
+          <div className="flex items-start justify-between gap-4">
+            <h1 className="text-3xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50">
+              {doc.frontmatter.title}
+            </h1>
+            <div className="mt-1.5 shrink-0">
+              <DownloadButton
+                content={doc.content}
+                filename={`${doc.frontmatter.title.toLowerCase().replace(/\s+/g, '-')}.md`}
+              />
+            </div>
+          </div>
           {doc.frontmatter.description && (
             <p className="mt-2 text-lg text-zinc-500 dark:text-zinc-400">
               {doc.frontmatter.description}

--- a/src/components/DownloadButton/index.tsx
+++ b/src/components/DownloadButton/index.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import type { DownloadButtonProps } from './types'
+
+export function DownloadButton({ content, filename }: DownloadButtonProps) {
+  function handleDownload() {
+    const blob = new Blob([content], { type: 'text/markdown' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <button
+      onClick={handleDownload}
+      title="Descargar como Markdown para usar como reglas en un agente AI"
+      className="inline-flex items-center gap-1.5 rounded-md border border-zinc-200 dark:border-zinc-700 px-2.5 py-1 text-xs text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 hover:border-zinc-400 dark:hover:border-zinc-500 transition-colors"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="12"
+        height="12"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+        <polyline points="7 10 12 15 17 10" />
+        <line x1="12" y1="15" x2="12" y2="3" />
+      </svg>
+      Download rules
+    </button>
+  )
+}

--- a/src/components/DownloadButton/types.ts
+++ b/src/components/DownloadButton/types.ts
@@ -1,0 +1,4 @@
+export interface DownloadButtonProps {
+  content: string
+  filename: string
+}


### PR DESCRIPTION
## Cambios
- Nuevo `src/components/DownloadButton/` — botón cliente con `'use client'`
- Recibe `content: string` (raw MDX sin frontmatter) y `filename: string`
- Crea un `Blob` de tipo `text/markdown` y dispara la descarga con `URL.createObjectURL`
- Integrado en el header de `app/docs/[...slug]/page.tsx` alineado a la derecha del título
- Filename generado desde el título del doc: `middleware.md`, `server-actions.md`, etc.

## Testing
- ✅ Build exitoso — 23 páginas
- ✅ TypeScript sin errores

Closes #53
Related to #52