### PR TITLE
feat: docs de Astro (routing, islas, content collections, integraciones)

### DIFF
--- a/src/content/docs/astro/content-collections.mdx
+++ b/src/content/docs/astro/content-collections.mdx
@@ -1,0 +1,185 @@
+---
+title: Content Collections
+description: Gestión de contenido tipado en Astro — definir esquemas con Zod, consultar colecciones y referencias entre ellas.
+order: 42
+---
+
+Las Content Collections son la forma nativa de Astro para gestionar archivos de contenido (Markdown, MDX, JSON, YAML) con tipado completo en TypeScript. Se definen en `src/content/` y se configuran en `src/content/config.ts`.
+
+## Configuración básica
+
+```ts
+// src/content/config.ts
+import { defineCollection, z } from 'astro:content'
+
+const blog = defineCollection({
+  type: 'content', // archivos .md o .mdx
+  schema: z.object({
+    title: z.string(),
+    description: z.string().optional(),
+    publishedAt: z.date(),
+    tags: z.array(z.string()).default([]),
+    draft: z.boolean().default(false),
+  }),
+})
+
+const authors = defineCollection({
+  type: 'data', // archivos .json o .yaml
+  schema: z.object({
+    name: z.string(),
+    email: z.string().email(),
+    avatar: z.string().url().optional(),
+  }),
+})
+
+export const collections = { blog, authors }
+```
+
+El esquema Zod valida el frontmatter en tiempo de build — si un archivo tiene datos incorrectos, el build falla con un mensaje claro.
+
+## Estructura de archivos
+
+```
+src/content/
+├── config.ts
+├── blog/
+│   ├── primer-post.md
+│   ├── segundo-post.mdx
+│   └── borrador.md
+└── authors/
+    ├── ana.json
+    └── carlos.yaml
+```
+
+## Consultar colecciones
+
+```astro
+---
+import { getCollection, getEntry } from 'astro:content'
+
+// Todos los posts (incluyendo borradores)
+const allPosts = await getCollection('blog')
+
+// Solo posts publicados
+const publishedPosts = await getCollection('blog', ({ data }) => !data.draft)
+
+// Ordenar por fecha
+const sortedPosts = publishedPosts.sort(
+  (a, b) => b.data.publishedAt.valueOf() - a.data.publishedAt.valueOf()
+)
+
+// Un post específico por slug
+const post = await getEntry('blog', 'primer-post')
+---
+```
+
+## Renderizar contenido
+
+```astro
+---
+import { getEntry } from 'astro:content'
+
+const post = await getEntry('blog', Astro.params.slug as string)
+if (!post) return Astro.redirect('/404')
+
+const { Content, headings } = await post.render()
+---
+
+<article>
+  <h1>{post.data.title}</h1>
+  <time>{post.data.publishedAt.toLocaleDateString()}</time>
+  <Content />
+</article>
+```
+
+`render()` devuelve el componente `Content` y los `headings` para generar un TOC.
+
+## Referencias entre colecciones
+
+```ts
+// src/content/config.ts
+import { defineCollection, reference, z } from 'astro:content'
+
+const blog = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    author: reference('authors'), // referencia tipada a la colección authors
+    relatedPosts: z.array(reference('blog')).optional(),
+  }),
+})
+```
+
+```md
+---
+title: Mi Post
+author: ana  # debe ser el slug de un entry en authors/
+relatedPosts:
+  - segundo-post
+---
+```
+
+```astro
+---
+import { getEntry } from 'astro:content'
+
+const post = await getEntry('blog', 'primer-post')
+
+// Resolver la referencia al autor
+const author = await getEntry(post.data.author)
+---
+
+<p>Por {author.data.name}</p>
+```
+
+<Callout type="tip">
+Las referencias garantizan en build time que el entry referenciado existe. Si `ana.json` no existe, el build falla con un error claro.
+</Callout>
+
+## Imágenes en el esquema
+
+```ts
+import { defineCollection, z } from 'astro:content'
+import { image } from 'astro:content'
+
+const blog = defineCollection({
+  schema: ({ image }) =>
+    z.object({
+      title: z.string(),
+      cover: image(), // valida y optimiza la imagen con astro:assets
+    }),
+})
+```
+
+```md
+---
+title: Post con imagen
+cover: ./cover.jpg
+---
+```
+
+Astro procesa la imagen con su pipeline de optimización automáticamente.
+
+## Filtrar y paginar
+
+```astro
+---
+import { getCollection } from 'astro:content'
+
+const PAGE_SIZE = 10
+const page = Number(Astro.params.page ?? 1)
+
+const allPosts = await getCollection('blog', ({ data }) => !data.draft)
+const totalPages = Math.ceil(allPosts.length / PAGE_SIZE)
+const posts = allPosts.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE)
+---
+```
+
+## Reglas clave
+
+- `config.ts` debe estar en `src/content/` — no en subdirectorios
+- El `type: 'content'` es para MD/MDX; `type: 'data'` para JSON/YAML
+- Los slugs se generan automáticamente desde el nombre del archivo (sin extensión)
+- Usa `reference()` en lugar de `z.string()` para IDs entre colecciones — da tipado y validación
+- El frontmatter no válido rompe el build, no el runtime — los errores aparecen temprano
+- `getCollection` siempre retorna un array (nunca `null`); `getEntry` puede retornar `undefined`

--- a/src/content/docs/astro/integraciones.mdx
+++ b/src/content/docs/astro/integraciones.mdx
@@ -1,0 +1,198 @@
+---
+title: Integraciones
+description: Agregar React, Tailwind, MDX y View Transitions a un proyecto Astro — configuración y mejores prácticas.
+order: 43
+---
+
+Astro se extiende mediante integraciones oficiales. Se instalan con `astro add` que configura automáticamente `astro.config.mjs` y las dependencias necesarias.
+
+## React
+
+```bash
+pnpm astro add react
+```
+
+Esto instala `@astrojs/react` y configura el plugin. Después puedes usar componentes `.tsx` en tus páginas `.astro`:
+
+```astro
+---
+import MyCounter from '../components/MyCounter.tsx'
+---
+
+<!-- Sin hidratación: solo HTML estático -->
+<MyCounter initialCount={0} />
+
+<!-- Con hidratación: interactivo en el cliente -->
+<MyCounter client:load initialCount={0} />
+```
+
+<Callout type="tip">
+Puedes mezclar múltiples frameworks (React + Vue + Svelte) en el mismo proyecto. Cada isla se hidrata de forma independiente.
+</Callout>
+
+## Tailwind CSS
+
+```bash
+pnpm astro add tailwind
+```
+
+Crea `tailwind.config.mjs` y agrega la integración en `astro.config.mjs`. Luego puedes usar Tailwind en cualquier archivo `.astro`, `.tsx`, `.vue`:
+
+```astro
+---
+// src/pages/index.astro
+---
+
+<main class="mx-auto max-w-4xl px-6 py-12">
+  <h1 class="text-4xl font-bold text-zinc-900">Hola mundo</h1>
+</main>
+```
+
+Para estilos globales adicionales, crea un archivo CSS e impórtalo en tu layout base:
+
+```astro
+---
+// src/layouts/Base.astro
+import '../styles/global.css'
+---
+```
+
+## MDX
+
+```bash
+pnpm astro add mdx
+```
+
+Permite usar componentes de React/Astro dentro de archivos `.mdx`:
+
+```mdx
+---
+title: Mi post con componentes
+---
+
+import { Callout } from '../components/Callout.astro'
+import Chart from '../components/Chart.tsx'
+
+## Sección con componentes
+
+<Callout type="info">
+  Este es un callout dentro de Markdown.
+</Callout>
+
+<Chart client:visible data={[1, 2, 3]} />
+```
+
+Para pasar componentes globalmente a todos los archivos MDX sin importarlos cada vez:
+
+```js
+// astro.config.mjs
+import mdx from '@astrojs/mdx'
+import { defineConfig } from 'astro/config'
+
+export default defineConfig({
+  integrations: [
+    mdx({
+      components: {
+        // Reemplazar elementos nativos de Markdown
+        h2: './src/components/Heading2.astro',
+        pre: './src/components/CodeBlock.astro',
+      },
+    }),
+  ],
+})
+```
+
+## View Transitions
+
+Las View Transitions permiten animaciones suaves entre páginas sin SPA completo. Astro las implementa con la API nativa del navegador y un fallback para navegadores sin soporte.
+
+```bash
+pnpm astro add @astrojs/view-transitions
+```
+
+Agrega el componente en el layout base:
+
+```astro
+---
+// src/layouts/Base.astro
+import { ViewTransitions } from 'astro:transitions'
+---
+
+<html>
+  <head>
+    <ViewTransitions />
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>
+```
+
+Animar elementos específicos con `transition:name`:
+
+```astro
+---
+// src/pages/blog/index.astro
+const posts = await getCollection('blog')
+---
+
+{posts.map((post) => (
+  <article>
+    <img
+      src={post.data.cover.src}
+      transition:name={`cover-${post.slug}`}
+    />
+    <h2 transition:name={`title-${post.slug}`}>{post.data.title}</h2>
+  </article>
+))}
+```
+
+```astro
+---
+// src/pages/blog/[slug].astro
+---
+
+<img
+  src={post.data.cover.src}
+  transition:name={`cover-${post.slug}`}
+/>
+<h1 transition:name={`title-${post.slug}`}>{post.data.title}</h1>
+```
+
+El navegador animará automáticamente los elementos con el mismo `transition:name` entre páginas.
+
+## Persistir estado entre navegaciones con View Transitions
+
+Por defecto, cada navegación destruye y recrea las islas. Para persistir un componente (ej: un reproductor de audio):
+
+```astro
+<MusicPlayer client:load transition:persist />
+```
+
+## Configuración completa de ejemplo
+
+```js
+// astro.config.mjs
+import { defineConfig } from 'astro/config'
+import react from '@astrojs/react'
+import tailwind from '@astrojs/tailwind'
+import mdx from '@astrojs/mdx'
+import { ViewTransitions } from 'astro:transitions'
+
+export default defineConfig({
+  integrations: [
+    react(),
+    tailwind(),
+    mdx(),
+  ],
+  output: 'static', // o 'server' para SSR
+})
+```
+
+## Reglas clave
+
+- Usa `pnpm astro add <integration>` en lugar de instalar manualmente — configura todo automáticamente
+- Las islas de React necesitan `@astrojs/react`; sin la integración el componente se renderiza como HTML estático sin hidratación posible
+- View Transitions funciona mejor con `transition:name` únicos por página — evita duplicados
+- `transition:persist` es útil para elementos globales (player, cart) que no deben re-montarse
+- Tailwind v4 requiere `@astrojs/tailwind@^6` — verifica la compatibilidad de versiones

--- a/src/content/docs/astro/islas.mdx
+++ b/src/content/docs/astro/islas.mdx
@@ -1,0 +1,142 @@
+---
+title: Componentes e islas
+description: Arquitectura de islas en Astro — cómo y cuándo hidratar componentes de UI interactivos.
+order: 41
+---
+
+Astro envía **cero JavaScript por defecto**. Los componentes de frameworks (React, Vue, Svelte) se renderizan a HTML estático en el servidor. Para añadir interactividad usas las directivas `client:*` — eso convierte el componente en una "isla" hidratada en el cliente.
+
+## Componentes .astro vs componentes de framework
+
+| `.astro` | React / Vue / Svelte |
+|---|---|
+| Solo se ejecutan en el servidor | Pueden ejecutarse en cliente también |
+| Sin estado reactivo | Con estado (`useState`, `ref`, etc.) |
+| Sin JS en el bundle por defecto | Requieren hidratación explícita |
+| Ideal para layouts, estructura, contenido | Ideal para widgets interactivos |
+
+## Directivas de hidratación
+
+```astro
+---
+import Counter from '../components/Counter.tsx'
+import HeavyWidget from '../components/HeavyWidget.tsx'
+import Modal from '../components/Modal.tsx'
+import Chart from '../components/Chart.tsx'
+---
+
+<!-- Hidrata inmediatamente al cargar la página -->
+<Counter client:load />
+
+<!-- Hidrata cuando el navegador está idle (no bloquea el render inicial) -->
+<HeavyWidget client:idle />
+
+<!-- Hidrata cuando el componente entra en el viewport -->
+<Chart client:visible />
+
+<!-- Hidrata solo en ciertos breakpoints (media query) -->
+<Modal client:media="(max-width: 768px)" />
+
+<!-- Solo hidrata en el cliente, sin SSR del componente -->
+<Counter client:only="react" />
+```
+
+<Callout type="tip">
+Usa `client:visible` para componentes pesados que están debajo del fold — no bloquean el LCP y se hidratan solo cuando el usuario los ve.
+</Callout>
+
+## Cuándo usar cada directiva
+
+| Directiva | Cuándo usarla |
+|---|---|
+| `client:load` | Componentes críticos que deben ser interactivos de inmediato (navbar, form principal) |
+| `client:idle` | Widgets no críticos que pueden esperar (chat, analytics) |
+| `client:visible` | Componentes debajo del fold (carruseles, tablas de precios) |
+| `client:media` | Componentes exclusivos de mobile o desktop |
+| `client:only` | Componentes que no tienen sentido en SSR (requieren `window`, `localStorage`) |
+
+## Pasar props a islas
+
+```astro
+---
+import SearchBar from '../components/SearchBar.tsx'
+
+const items = await fetchItems()
+---
+
+<SearchBar client:load items={items} placeholder="Buscar..." />
+```
+
+Los props se serializan para enviarse al cliente. Solo pueden ser valores serializables: strings, números, arrays, objetos planos. No funciones ni clases.
+
+## Compartir estado entre islas
+
+Las islas son independientes — no comparten estado por defecto. Para estado compartido usa una store externa como **nanostores** (recomendado para Astro por su tamaño mínimo):
+
+```ts
+// src/stores/cart.ts
+import { atom, computed } from 'nanostores'
+
+export const cartItems = atom<CartItem[]>([])
+export const cartCount = computed(cartItems, (items) => items.length)
+```
+
+```tsx
+// src/components/CartIcon.tsx
+import { useStore } from '@nanostores/react'
+import { cartCount } from '../stores/cart'
+
+export function CartIcon() {
+  const count = useStore(cartCount)
+  return <button>Cart ({count})</button>
+}
+```
+
+```tsx
+// src/components/AddToCart.tsx
+import { cartItems } from '../stores/cart'
+
+export function AddToCart({ item }: { item: CartItem }) {
+  function add() {
+    cartItems.set([...cartItems.get(), item])
+  }
+  return <button onClick={add}>Agregar</button>
+}
+```
+
+Ambas islas están sincronizadas aunque estén en partes distintas de la página.
+
+## Componentes Astro con slots
+
+Para composición sin JS, usa `<slot>` en componentes `.astro`:
+
+```astro
+---
+// src/components/Card.astro
+interface Props {
+  title: string
+}
+const { title } = Astro.props
+---
+
+<div class="card">
+  <h2>{title}</h2>
+  <slot /> <!-- contenido del hijo -->
+  <slot name="footer" /> <!-- slot nombrado -->
+</div>
+```
+
+```astro
+<Card title="Mi card">
+  <p>Contenido principal</p>
+  <div slot="footer">Footer aquí</div>
+</Card>
+```
+
+## Reglas clave
+
+- Un componente sin `client:*` no envía nada de JS al navegador
+- `client:only` omite el SSR completamente — el componente no renderiza HTML en el servidor
+- Los props deben ser serializables: no pases funciones ni instancias de clases a las islas
+- Para estado compartido entre islas usa nanostores; para estado global complejo considera Zustand con `client:only`
+- Prefiere `client:visible` sobre `client:load` para mejorar el LCP de la página

--- a/src/content/docs/astro/routing.mdx
+++ b/src/content/docs/astro/routing.mdx
@@ -1,0 +1,139 @@
+---
+title: Routing y páginas
+description: Cómo funciona el routing basado en archivos de Astro — rutas estáticas, dinámicas, SSG y SSR.
+order: 40
+---
+
+Astro usa routing basado en el sistema de archivos. Cada archivo en `src/pages/` se convierte en una ruta. No hay configuración adicional.
+
+## Rutas estáticas
+
+```
+src/pages/
+├── index.astro          → /
+├── about.astro          → /about
+└── blog/
+    ├── index.astro      → /blog
+    └── primer-post.astro → /blog/primer-post
+```
+
+## Rutas dinámicas con `getStaticPaths`
+
+Para generar múltiples páginas desde datos (blog posts, productos), usa corchetes en el nombre del archivo y exporta `getStaticPaths`.
+
+```astro
+---
+// src/pages/blog/[slug].astro
+import { getCollection } from 'astro:content'
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog')
+
+  return posts.map((post) => ({
+    params: { slug: post.slug },
+    props: { post },
+  }))
+}
+
+const { post } = Astro.props
+const { Content } = await post.render()
+---
+
+<article>
+  <h1>{post.data.title}</h1>
+  <Content />
+</article>
+```
+
+Cada objeto en el array retornado genera una página. `params` define la URL, `props` pasa datos al componente.
+
+## Rutas con segmentos rest
+
+Para rutas con profundidad variable (docs anidadas), usa `[...slug]`:
+
+```
+src/pages/docs/[...slug].astro  →  /docs/react/hooks, /docs/nextjs/middleware, etc.
+```
+
+```astro
+---
+export async function getStaticPaths() {
+  const docs = await getCollection('docs')
+
+  return docs.map((doc) => ({
+    params: { slug: doc.slug },
+    props: { doc },
+  }))
+}
+---
+```
+
+## SSG vs SSR por ruta
+
+Por defecto Astro genera páginas estáticas (SSG). Para SSR necesitas un adaptador y activar el modo por archivo:
+
+```astro
+---
+// Activar SSR solo en esta página
+export const prerender = false
+
+// Acceder a datos de la request
+const user = Astro.locals.user
+const { id } = Astro.params
+---
+```
+
+O configurar SSR global en `astro.config.mjs` y marcar páginas estáticas con `export const prerender = true`.
+
+## Redirecciones
+
+```js
+// astro.config.mjs
+export default defineConfig({
+  redirects: {
+    '/old-blog': '/blog',
+    '/old-blog/[slug]': '/blog/[slug]',
+  },
+})
+```
+
+## Pasar datos entre layout y página
+
+```astro
+---
+// src/pages/about.astro
+import Layout from '../layouts/Base.astro'
+---
+
+<Layout title="About" description="Sobre nosotros">
+  <h1>About</h1>
+</Layout>
+```
+
+```astro
+---
+// src/layouts/Base.astro
+interface Props {
+  title: string
+  description?: string
+}
+const { title, description } = Astro.props
+---
+
+<html>
+  <head>
+    <title>{title}</title>
+    {description && <meta name="description" content={description} />}
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>
+```
+
+## Reglas clave
+
+- El archivo `index.astro` dentro de una carpeta mapea a la raíz de esa ruta (`/blog/index.astro` → `/blog`)
+- `getStaticPaths` solo puede usarse en archivos con parámetros dinámicos (`[slug].astro`)
+- En SSR, `getStaticPaths` no existe — los params se leen de `Astro.params` en runtime
+- Usa `Astro.redirect('/ruta')` para redirecciones programáticas dentro del frontmatter


### PR DESCRIPTION
## Cambios
Nueva sección **Astro** en el sidebar con 4 docs:

- `routing.mdx` — routing basado en archivos, `getStaticPaths`, rutas rest `[...slug]`, SSG vs SSR, redirecciones
- `islas.mdx` — arquitectura de islas, todas las directivas `client:*` con tabla de cuándo usar cada una, nanostores para estado compartido entre islas, slots en componentes `.astro`
- `content-collections.mdx` — esquemas Zod, `getCollection` / `getEntry`, `render()`, referencias tipadas con `reference()`, imágenes, paginación
- `integraciones.mdx` — `astro add`, React, Tailwind, MDX con componentes globales, View Transitions con `transition:name` y `transition:persist`

## Testing
- ✅ Build exitoso — 27 páginas generadas (4 nuevas)
- ✅ TypeScript sin errores
- ✅ Sección Astro aparece como grupo en el sidebar

Closes #57
Related to #56