### PR TITLE
feat(cli): tipos compartidos TypeScript

### DIFF
--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,0 +1,44 @@
+export interface CatalogIndex {
+  categories: CategoryRef[]
+}
+
+export interface CategoryRef {
+  id: string
+  label: string
+  indexUrl: string
+}
+
+export interface CategoryIndex {
+  category: string
+  label: string
+  items: string[]
+}
+
+export interface ManifestItem {
+  id: string
+  name: string
+  description: string
+  category: string
+  tags: string[]
+  deps: {
+    dependencies: string[]
+    devDependencies: string[]
+  }
+  files: FileEntry[]
+  docsUrl: string
+}
+
+export interface FileEntry {
+  src: string
+  dest: string
+}
+
+export interface InstallResult {
+  path: string
+  skipped: boolean
+}
+
+export interface InstallStep {
+  label: string
+  status: 'pending' | 'running' | 'done' | 'skipped' | 'error'
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -14,16 +14,18 @@ export interface CategoryIndex {
   items: string[]
 }
 
+export interface DepsMap {
+  dependencies: string[]
+  devDependencies: string[]
+}
+
 export interface ManifestItem {
   id: string
   name: string
   description: string
   category: string
   tags: string[]
-  deps: {
-    dependencies: string[]
-    devDependencies: string[]
-  }
+  deps: DepsMap
   files: FileEntry[]
   docsUrl: string
 }
@@ -36,6 +38,7 @@ export interface FileEntry {
 export interface InstallResult {
   path: string
   skipped: boolean
+  error?: string
 }
 
 export interface InstallStep {


### PR DESCRIPTION
## Summary

- Crea `packages/cli/src/types.ts` con 7 interfaces compartidas para el sistema de catálogo CLI
- Añade `DepsMap` como interfaz separada (en lugar de tipo inline en `ManifestItem`)
- Añade campo opcional `error?: string` a `InstallResult` para manejo de errores en install logic

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)