### PR TITLE
feat(cli): lib/package-manager — detectar pnpm/yarn/npm

### DIFF
--- a/packages/cli/src/lib/package-manager.test.ts
+++ b/packages/cli/src/lib/package-manager.test.ts
@@ -59,4 +59,8 @@ describe('getInstallCommand', () => {
   it('npm devDeps: npm install --save-dev', () => {
     expect(getInstallCommand('npm', ['vitest'], true)).toBe('npm install --save-dev vitest')
   })
+
+  it('lanza error si deps está vacío', () => {
+    expect(() => getInstallCommand('pnpm', [])).toThrow('deps must not be empty')
+  })
 })

--- a/packages/cli/src/lib/package-manager.test.ts
+++ b/packages/cli/src/lib/package-manager.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { existsSync } from 'fs'
+import { detectPackageManager, getInstallCommand } from './package-manager.js'
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+}))
+
+describe('detectPackageManager', () => {
+  afterEach(() => vi.resetAllMocks())
+
+  it('detecta pnpm por pnpm-lock.yaml', () => {
+    vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith('pnpm-lock.yaml'))
+    expect(detectPackageManager('/fake/dir')).toBe('pnpm')
+  })
+
+  it('detecta yarn por yarn.lock', () => {
+    vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith('yarn.lock'))
+    expect(detectPackageManager('/fake/dir')).toBe('yarn')
+  })
+
+  it('detecta npm por package-lock.json', () => {
+    vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith('package-lock.json'))
+    expect(detectPackageManager('/fake/dir')).toBe('npm')
+  })
+
+  it('devuelve null si no hay lockfile', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    expect(detectPackageManager('/fake/dir')).toBeNull()
+  })
+
+  it('prioriza pnpm sobre los demás', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    expect(detectPackageManager('/fake/dir')).toBe('pnpm')
+  })
+})
+
+describe('getInstallCommand', () => {
+  it('pnpm: pnpm add deps', () => {
+    expect(getInstallCommand('pnpm', ['zod', 'react-hook-form'])).toBe('pnpm add zod react-hook-form')
+  })
+
+  it('yarn: yarn add deps', () => {
+    expect(getInstallCommand('yarn', ['zod'])).toBe('yarn add zod')
+  })
+
+  it('npm: npm install deps', () => {
+    expect(getInstallCommand('npm', ['zod'])).toBe('npm install zod')
+  })
+
+  it('pnpm devDeps: pnpm add -D', () => {
+    expect(getInstallCommand('pnpm', ['vitest'], true)).toBe('pnpm add -D vitest')
+  })
+
+  it('yarn devDeps: yarn add -D', () => {
+    expect(getInstallCommand('yarn', ['vitest'], true)).toBe('yarn add -D vitest')
+  })
+
+  it('npm devDeps: npm install --save-dev', () => {
+    expect(getInstallCommand('npm', ['vitest'], true)).toBe('npm install --save-dev vitest')
+  })
+})

--- a/packages/cli/src/lib/package-manager.ts
+++ b/packages/cli/src/lib/package-manager.ts
@@ -11,8 +11,11 @@ export function detectPackageManager(cwd: string = process.cwd()): PackageManage
 }
 
 export function getInstallCommand(pm: PackageManager, deps: string[], dev = false): string {
+  if (deps.length === 0) throw new Error('deps must not be empty')
   const depStr = deps.join(' ')
   if (pm === 'pnpm') return dev ? `pnpm add -D ${depStr}` : `pnpm add ${depStr}`
   if (pm === 'yarn') return dev ? `yarn add -D ${depStr}` : `yarn add ${depStr}`
-  return dev ? `npm install --save-dev ${depStr}` : `npm install ${depStr}`
+  if (pm === 'npm') return dev ? `npm install --save-dev ${depStr}` : `npm install ${depStr}`
+  const _exhaustive: never = pm
+  throw new Error(`Unhandled package manager: ${_exhaustive}`)
 }

--- a/packages/cli/src/lib/package-manager.ts
+++ b/packages/cli/src/lib/package-manager.ts
@@ -1,0 +1,18 @@
+import { existsSync } from 'fs'
+import { join } from 'path'
+
+export type PackageManager = 'pnpm' | 'yarn' | 'npm'
+
+export function detectPackageManager(cwd: string = process.cwd()): PackageManager | null {
+  if (existsSync(join(cwd, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (existsSync(join(cwd, 'yarn.lock'))) return 'yarn'
+  if (existsSync(join(cwd, 'package-lock.json'))) return 'npm'
+  return null
+}
+
+export function getInstallCommand(pm: PackageManager, deps: string[], dev = false): string {
+  const depStr = deps.join(' ')
+  if (pm === 'pnpm') return dev ? `pnpm add -D ${depStr}` : `pnpm add ${depStr}`
+  if (pm === 'yarn') return dev ? `yarn add -D ${depStr}` : `yarn add ${depStr}`
+  return dev ? `npm install --save-dev ${depStr}` : `npm install ${depStr}`
+}


### PR DESCRIPTION
## Summary

- Crea `packages/cli/src/lib/package-manager.ts` con `detectPackageManager` y `getInstallCommand`
- 12 tests (TDD) cubriendo detección por lockfile, prioridad pnpm, comandos por PM, devDeps, y guard de empty deps
- Guard contra array vacío y exhaustiveness check para cuando el tipo PackageManager se extienda

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)