### PR TITLE
feat(cli): lib/scaffolder — ejecutar create-next-app/vite/astro

### DIFF
--- a/packages/cli/src/lib/scaffolder.test.ts
+++ b/packages/cli/src/lib/scaffolder.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest'
+import { spawnSync } from 'child_process'
+import { scaffold } from './scaffolder.js'
+
+vi.mock('child_process', () => ({
+  spawnSync: vi.fn(() => ({ status: 0 })),
+}))
+
+describe('scaffold', () => {
+  it('react-vite: corre npm create vite@latest', () => {
+    scaffold('react-vite', 'my-app')
+    expect(spawnSync).toHaveBeenCalledWith(
+      'npm',
+      ['create', 'vite@latest', 'my-app'],
+      { stdio: 'inherit', shell: true }
+    )
+  })
+
+  it('nextjs: corre npx create-next-app@latest', () => {
+    scaffold('nextjs', 'my-app')
+    expect(spawnSync).toHaveBeenCalledWith(
+      'npx',
+      ['create-next-app@latest', 'my-app'],
+      { stdio: 'inherit', shell: true }
+    )
+  })
+
+  it('astro: corre npm create astro@latest', () => {
+    scaffold('astro', 'my-app')
+    expect(spawnSync).toHaveBeenCalledWith(
+      'npm',
+      ['create', 'astro@latest', 'my-app'],
+      { stdio: 'inherit', shell: true }
+    )
+  })
+
+  it('retorna true cuando status es 0', () => {
+    expect(scaffold('react-vite', 'my-app')).toBe(true)
+  })
+
+  it('retorna false cuando status es distinto de 0', () => {
+    vi.mocked(spawnSync).mockReturnValueOnce({ status: 1 } as ReturnType<typeof spawnSync>)
+    expect(scaffold('nextjs', 'my-app')).toBe(false)
+  })
+})

--- a/packages/cli/src/lib/scaffolder.test.ts
+++ b/packages/cli/src/lib/scaffolder.test.ts
@@ -42,4 +42,9 @@ describe('scaffold', () => {
     vi.mocked(spawnSync).mockReturnValueOnce({ status: 1 } as ReturnType<typeof spawnSync>)
     expect(scaffold('nextjs', 'my-app')).toBe(false)
   })
+
+  it('lanza error cuando status es null (comando no encontrado)', () => {
+    vi.mocked(spawnSync).mockReturnValueOnce({ status: null, error: new Error('spawn npm ENOENT'), signal: null } as unknown as ReturnType<typeof spawnSync>)
+    expect(() => scaffold('react-vite', 'my-app')).toThrow('spawn npm ENOENT')
+  })
 })

--- a/packages/cli/src/lib/scaffolder.ts
+++ b/packages/cli/src/lib/scaffolder.ts
@@ -1,0 +1,17 @@
+import { spawnSync } from 'child_process'
+
+export type Stack = 'react-vite' | 'nextjs' | 'astro'
+
+type Command = [string, string[]]
+
+const COMMANDS: Record<Stack, Command> = {
+  'react-vite': ['npm', ['create', 'vite@latest']],
+  'nextjs': ['npx', ['create-next-app@latest']],
+  'astro': ['npm', ['create', 'astro@latest']],
+}
+
+export function scaffold(stack: Stack, projectName: string): boolean {
+  const [cmd, args] = COMMANDS[stack]
+  const result = spawnSync(cmd, [...args, projectName], { stdio: 'inherit', shell: true })
+  return result.status === 0
+}

--- a/packages/cli/src/lib/scaffolder.ts
+++ b/packages/cli/src/lib/scaffolder.ts
@@ -13,5 +13,8 @@ const COMMANDS: Record<Stack, Command> = {
 export function scaffold(stack: Stack, projectName: string): boolean {
   const [cmd, args] = COMMANDS[stack]
   const result = spawnSync(cmd, [...args, projectName], { stdio: 'inherit', shell: true })
+  if (result.status === null) {
+    throw result.error ?? new Error(`Spawning ${cmd} failed (signal: ${result.signal})`)
+  }
   return result.status === 0
 }


### PR DESCRIPTION
## Summary

- Crea `packages/cli/src/lib/scaffolder.ts` con `scaffold(stack, projectName): boolean`
- Soporta react-vite, nextjs, astro via spawnSync con `stdio: 'inherit'`
- Lanza error si spawnSync retorna `status: null` (comando no encontrado)
- 6 tests TDD

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)