### PR TITLE
feat(cli): commands/add y commands/create

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,0 +1,49 @@
+import { execSync } from 'child_process'
+import { fetchCatalogIndex, fetchCategoryIndex, fetchManifest } from '../lib/fetcher.js'
+import { installFiles } from '../lib/installer.js'
+import { detectPackageManager, getInstallCommand } from '../lib/package-manager.js'
+import type { CategoryRef, ManifestItem, InstallStep } from '../types.js'
+
+export async function loadCatalog(): Promise<CategoryRef[]> {
+  const index = await fetchCatalogIndex()
+  return index.categories
+}
+
+export async function loadCategoryItems(categoryId: string): Promise<ManifestItem[]> {
+  const catIndex = await fetchCategoryIndex(categoryId)
+  return Promise.all(catIndex.items.map((id) => fetchManifest(categoryId, id)))
+}
+
+export async function runInstall(
+  manifests: ManifestItem[],
+  cwd: string,
+  onStep: (step: InstallStep) => void
+): Promise<string | null> {
+  const pm = detectPackageManager(cwd) ?? 'npm'
+  let lastDocsUrl: string | null = null
+
+  for (const manifest of manifests) {
+    const fileResults = await installFiles(manifest, cwd)
+    for (const result of fileResults) {
+      onStep({ label: result.path, status: result.skipped ? 'skipped' : 'done' })
+    }
+
+    if (manifest.deps.dependencies.length > 0) {
+      const cmd = getInstallCommand(pm, manifest.deps.dependencies)
+      onStep({ label: cmd, status: 'running' })
+      execSync(cmd, { cwd, stdio: 'pipe' })
+      onStep({ label: cmd, status: 'done' })
+    }
+
+    if (manifest.deps.devDependencies.length > 0) {
+      const cmd = getInstallCommand(pm, manifest.deps.devDependencies, true)
+      onStep({ label: cmd, status: 'running' })
+      execSync(cmd, { cwd, stdio: 'pipe' })
+      onStep({ label: cmd, status: 'done' })
+    }
+
+    lastDocsUrl = manifest.docsUrl
+  }
+
+  return lastDocsUrl
+}

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -25,21 +25,31 @@ export async function runInstall(
   for (const manifest of manifests) {
     const fileResults = await installFiles(manifest, cwd)
     for (const result of fileResults) {
-      onStep({ label: result.path, status: result.skipped ? 'skipped' : 'done' })
+      onStep({ label: result.path, status: result.error ? 'error' : result.skipped ? 'skipped' : 'done' })
     }
 
     if (manifest.deps.dependencies.length > 0) {
       const cmd = getInstallCommand(pm, manifest.deps.dependencies)
       onStep({ label: cmd, status: 'running' })
-      execSync(cmd, { cwd, stdio: 'pipe' })
-      onStep({ label: cmd, status: 'done' })
+      try {
+        execSync(cmd, { cwd, stdio: 'pipe' })
+        onStep({ label: cmd, status: 'done' })
+      } catch {
+        onStep({ label: cmd, status: 'error' })
+        throw new Error(`Failed to install dependencies: ${cmd}`)
+      }
     }
 
     if (manifest.deps.devDependencies.length > 0) {
       const cmd = getInstallCommand(pm, manifest.deps.devDependencies, true)
       onStep({ label: cmd, status: 'running' })
-      execSync(cmd, { cwd, stdio: 'pipe' })
-      onStep({ label: cmd, status: 'done' })
+      try {
+        execSync(cmd, { cwd, stdio: 'pipe' })
+        onStep({ label: cmd, status: 'done' })
+      } catch {
+        onStep({ label: cmd, status: 'error' })
+        throw new Error(`Failed to install devDependencies: ${cmd}`)
+      }
     }
 
     lastDocsUrl = manifest.docsUrl

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,0 +1,8 @@
+import { scaffold } from '../lib/scaffolder.js'
+import type { Stack } from '../lib/scaffolder.js'
+
+export type { Stack }
+
+export function createProject(stack: Stack, projectName: string): boolean {
+  return scaffold(stack, projectName)
+}


### PR DESCRIPTION
## Summary

- Crea `packages/cli/src/commands/add.ts`: `loadCatalog`, `loadCategoryItems`, `runInstall` con manejo de errores en execSync e installFiles
- Crea `packages/cli/src/commands/create.ts`: re-export de `Stack` + `createProject` wrapper

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)