### PR TITLE
chore(cli): build verificado + ignorar dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# CLI build output
+packages/cli/dist/


### PR DESCRIPTION
## Summary

- Build del CLI compila sin errores: `tsup` → `dist/index.js` (17KB ESM) con shebang `#!/usr/bin/env node`
- 32 tests pasan
- Añade `packages/cli/dist/` a `.gitignore`

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)