### PR TITLE
feat: CLI/TUI installer — npx sanghel-playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # dependencies
 /node_modules
+node_modules
 /.pnp
 .pnp.*
 .yarn/*

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# CLI build output
+packages/cli/dist/

--- a/catalog/astro/index.json
+++ b/catalog/astro/index.json
@@ -1,0 +1,5 @@
+{
+  "category": "astro",
+  "label": "Astro",
+  "items": []
+}

--- a/catalog/index.json
+++ b/catalog/index.json
@@ -1,0 +1,8 @@
+{
+  "categories": [
+    { "id": "react", "label": "React", "indexUrl": "catalog/react/index.json" },
+    { "id": "nextjs", "label": "Next.js", "indexUrl": "catalog/nextjs/index.json" },
+    { "id": "astro", "label": "Astro", "indexUrl": "catalog/astro/index.json" },
+    { "id": "rules", "label": "Rules & Guides", "indexUrl": "catalog/rules/index.json" }
+  ]
+}

--- a/catalog/nextjs/index.json
+++ b/catalog/nextjs/index.json
@@ -1,0 +1,5 @@
+{
+  "category": "nextjs",
+  "label": "Next.js",
+  "items": []
+}

--- a/catalog/react/index.json
+++ b/catalog/react/index.json
@@ -1,0 +1,5 @@
+{
+  "category": "react",
+  "label": "React",
+  "items": []
+}

--- a/catalog/rules/deploy-guide/files/deploy-guide.md
+++ b/catalog/rules/deploy-guide/files/deploy-guide.md
@@ -1,0 +1,264 @@
+# 02 - GUÍA DE DEPLOY
+
+## 🚀 Deploy en Vercel
+
+Esta guía cubre el proceso completo de deploy del proyecto sanghel-playbook.
+
+---
+
+## 📋 Resumen de Arquitectura
+
+```
+┌─────────────────────────────────────┐
+│  Usuario                             │
+└──────────────┬──────────────────────┘
+               │
+               ▼
+┌─────────────────────────────────────┐
+│  Frontend (Next.js)                  │
+│  Deploy: Vercel                      │
+│  URL: sanghel-playbook.vercel.app   │
+└─────────────────────────────────────┘
+```
+
+---
+
+## PARTE 1: PRE-DEPLOY (Preparación)
+
+### 1.1. Verificar Build Local
+
+Antes de deployar, asegúrate de que todo funciona localmente:
+
+```bash
+pnpm install
+pnpm build
+pnpm start
+# Abrir http://localhost:3000
+```
+
+**Verificar:**
+
+- ✅ No hay errores de TypeScript
+- ✅ No hay errores de build
+- ✅ La aplicación se ve correcta
+- ✅ Todas las páginas y rutas funcionan
+
+### 1.2. Verificar Variables de Entorno
+
+Si el proyecto requiere variables de entorno, mantener un archivo `.env.local.example`:
+
+```env
+# Ejemplo — agregar las variables reales cuando sean necesarias
+# NEXT_PUBLIC_SITE_URL=
+```
+
+**⚠️ NO incluir valores reales en `.env.local.example`**
+
+### 1.3. Actualizar .gitignore
+
+Asegúrate de que `.gitignore` incluye:
+
+```gitignore
+.env
+.env.local
+.env.*.local
+.env.production
+.next/
+out/
+.vercel
+```
+
+### 1.4. Push Final a GitHub
+
+```bash
+git checkout main
+git pull origin main
+git status
+git push origin main
+```
+
+---
+
+## PARTE 2: CONFIGURAR VERCEL
+
+### 2.1. Instalar Vercel CLI (opcional pero recomendado)
+
+```bash
+npm install -g vercel
+vercel --version
+vercel login
+```
+
+### 2.2. Importar Proyecto desde GitHub
+
+**Opción A - Vercel Web (Recomendado para primera vez):**
+
+1. En dashboard de Vercel, click **"Add New Project"**
+2. Click **"Import Git Repository"**
+3. Selecciona `sanghel-playbook`
+4. Click **"Import"**
+
+**Opción B - Vercel CLI:**
+
+```bash
+cd sanghel-playbook
+vercel
+# Framework Preset: Next.js (auto-detectado)
+# Root Directory: ./
+```
+
+### 2.3. Configurar Proyecto en Vercel
+
+Vercel detecta Next.js automáticamente. Si no:
+
+- **Framework Preset**: Next.js
+- **Build Command**: `pnpm build`
+- **Output Directory**: `.next`
+- **Install Command**: `pnpm install`
+
+---
+
+## PARTE 3: VARIABLES DE ENTORNO EN VERCEL
+
+Si se agregan variables de entorno en el futuro:
+
+1. Settings del proyecto → **"Environment Variables"**
+2. Agregar cada variable con su scope (Production / Preview / Development)
+3. Click **"Save"** y hacer redeploy
+
+---
+
+## PARTE 4: DEPLOY
+
+### 4.1. Deploy Automático desde GitHub
+
+Vercel deployará automáticamente cuando:
+
+- Hagas push a `main` → deploy de **producción**
+- Hagas push a cualquier otra rama → deploy de **preview**
+- Abras un PR → deploy de **preview** asociado al PR
+
+### 4.2. Deploy Manual (CLI)
+
+```bash
+# Deploy a producción
+vercel --prod
+
+# Deploy a preview
+vercel
+```
+
+### 4.3. Monitorear el Deploy
+
+1. Ve a https://vercel.com/[tu-usuario]/sanghel-playbook
+2. Click en el deployment más reciente
+3. Estados: **Building** → **Deploying** → **Ready**
+
+### 4.4. Verificar Logs de Build
+
+Si hay errores:
+
+1. Click en el deployment → **"Build Logs"**
+2. Errores comunes:
+   - TypeScript no compila
+   - Dependencia faltante en `package.json`
+   - Variable de entorno faltante
+
+---
+
+## PARTE 5: BRANCHES Y DEPLOY
+
+**Configuración recomendada:**
+
+- `main` → Deploy de **Producción**
+- `develop` → Deploy de **Preview**
+- `feature/*` → Deploy de **Preview**
+
+**Configurar en Vercel:**
+
+1. Settings → **"Git"**
+2. **Production Branch**: `main`
+3. ✅ **Auto-deploy**: Enabled
+4. ✅ **Preview Deployments**: All branches
+
+**Proteger rama main en GitHub:**
+
+1. Settings del repo → **"Branches"** → **"Branch protection rules"**
+2. Regla para `main`:
+   - ✅ Require pull request reviews
+   - ✅ Require status checks to pass (Vercel)
+3. Save
+
+---
+
+## PARTE 6: DOMINIO CUSTOM (Opcional)
+
+```
+Settings → Domains → Add → ingresar tu dominio
+```
+
+Configurar DNS con el CNAME o A Record que Vercel indique.
+
+---
+
+## PARTE 7: ROLLBACK
+
+**Opción A - Vercel Dashboard:**
+
+1. Ve a **"Deployments"**
+2. Encuentra el deployment anterior funcional
+3. Click **"..."** → **"Promote to Production"**
+
+**Opción B - CLI:**
+
+```bash
+vercel rollback
+```
+
+---
+
+## PARTE 8: VERIFICACIÓN POST-DEPLOY
+
+- [ ] ✅ La página carga correctamente
+- [ ] ✅ Las rutas de docs funcionan (`/docs/[slug]`)
+- [ ] ✅ El tema (light/dark) funciona
+- [ ] ✅ El MDX renderiza correctamente
+- [ ] ✅ Syntax highlighting activo
+- [ ] ✅ Responsive en móvil
+- [ ] ✅ No hay errores en consola del navegador
+
+---
+
+## PARTE 9: MONITOREO
+
+**Vercel Analytics (gratis):**
+
+Activar desde el dashboard del proyecto → **"Analytics"**
+
+- Web Vitals
+- Real User Monitoring
+- Pageviews
+
+**Logs en tiempo real (CLI):**
+
+```bash
+vercel logs --prod
+vercel logs --prod | grep "ERROR"
+```
+
+---
+
+## 📞 Recursos Útiles
+
+- **Vercel Docs**: https://vercel.com/docs
+- **Next.js Deploy**: https://nextjs.org/docs/deployment
+- **Vercel Status**: https://www.vercel-status.com
+
+---
+
+## 🎉 ¡Deploy Completado!
+
+**URLs Importantes:**
+
+- Frontend: `https://sanghel-playbook.vercel.app`
+- GitHub: `https://github.com/Sanghel/sanghel-playbook`

--- a/catalog/rules/deploy-guide/manifest.json
+++ b/catalog/rules/deploy-guide/manifest.json
@@ -1,0 +1,15 @@
+{
+  "id": "deploy-guide",
+  "name": "Deploy Guide (Vercel)",
+  "description": "Checklist completo de deploy en Vercel: configuración, variables de entorno, monitoreo y rollback",
+  "category": "rules",
+  "tags": ["deploy", "vercel", "ci-cd", "checklist"],
+  "deps": {
+    "dependencies": [],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/deploy-guide.md", "dest": "rules/deploy-guide.md" }
+  ],
+  "docsUrl": "https://sanghel-playbook.vercel.app/docs/catalog/rules/deploy-guide"
+}

--- a/catalog/rules/github-flow/files/github-flow.md
+++ b/catalog/rules/github-flow/files/github-flow.md
@@ -1,0 +1,830 @@
+# 01 - FLUJO GIT Y GITHUB
+
+## 📖 Guía Completa del Workflow de Git Flow
+
+Este documento explica el flujo de trabajo con Git y GitHub que se usará durante todo el desarrollo del proyecto.
+
+---
+
+## 🌳 Estructura de Ramas
+
+```
+main (producción - protegida)
+  ↑
+  │ (PR al final de cada FASE)
+  │
+develop (integración - default)
+  ↑
+  │ (PRs de cada tarea)
+  │
+feature/[issue-number]-[descripcion] (tareas individuales)
+```
+
+### Descripción de Ramas:
+
+- **`main`**: Rama de producción
+  - Solo código estable y probado
+  - Deploy automático a Vercel
+  - Protegida: solo acepta PRs de `develop`
+  - Nunca se trabaja directamente aquí
+
+- **`develop`**: Rama de desarrollo
+  - Integración de todas las tareas
+  - Rama por defecto del repositorio
+  - Base para crear ramas `feature/*`
+  - Siempre debe estar funcional
+
+- **`feature/[issue-number]-[descripcion]`**: Ramas de tareas
+  - Una rama por tarea/issue
+  - Se crean desde `develop`
+  - Se fusionan de vuelta a `develop` vía PR
+  - Se eliminan después del merge
+
+---
+
+## 🔄 Flujo de Trabajo por Fase
+
+### FASE N - Flujo Completo
+
+```
+┌──────────────────────────────────────┐
+│  1. INICIO DE FASE                   │
+│  - Crear issue de FASE               │
+│  - Anotar número (#15 ejemplo)       │
+└──────────────┬───────────────────────┘
+               │
+               ▼
+┌──────────────────────────────────────┐
+│  2. POR CADA TAREA                   │
+│  ┌────────────────────────────────┐  │
+│  │ a) Crear issue de tarea        │  │
+│  │ b) Crear rama feature          │  │
+│  │ c) Desarrollar                 │  │
+│  │ d) Commit y push               │  │
+│  │ e) Crear PR a develop          │  │
+│  │ f) Code review                 │  │
+│  │ g) Merge PR                    │  │
+│  │ h) Cerrar issue                │  │
+│  └────────────────────────────────┘  │
+│  (Repetir para todas las tareas)     │
+└──────────────┬───────────────────────┘
+               │
+               ▼
+┌──────────────────────────────────────┐
+│  3. FIN DE FASE                      │
+│  - Build y verificación              │
+│  - PR develop → main                 │
+│  - ⚠️ DETENER DESARROLLO             │
+│  - 📢 NOTIFICAR                      │
+│  - ⏸️ ESPERAR APROBACIÓN             │
+└──────────────┬───────────────────────┘
+               │
+               ▼
+┌──────────────────────────────────────┐
+│  4. DESPUÉS DE APROBACIÓN            │
+│  - Merge PR                          │
+│  - Cerrar issue de FASE              │
+│  - Actualizar develop                │
+│  - Continuar con siguiente fase      │
+└──────────────────────────────────────┘
+```
+
+---
+
+## 📝 Comandos Git Detallados
+
+### INICIO DE FASE
+
+#### 1. Crear Issue de Fase en GitHub
+
+```bash
+gh issue create \
+  --title "FASE [N]: [Nombre de la fase]" \
+  --body "## Objetivo
+Descripción de lo que se logrará en esta fase.
+
+## Tareas
+- [ ] Tarea 1
+- [ ] Tarea 2
+...
+
+## Criterios de Aceptación
+- Todas las tareas completadas
+- Build exitoso
+- Funcionalidad probada"
+```
+
+**Anotar el número de issue** (ejemplo: #15)
+
+---
+
+### POR CADA TAREA
+
+#### 1. Asegurarse de estar en develop actualizado
+
+```bash
+# Cambiar a develop
+git checkout develop
+
+# Descargar últimos cambios
+git pull origin develop
+
+# Verificar estado limpio
+git status
+```
+
+#### 2. Crear Issue de Tarea
+
+```bash
+gh issue create \
+  --title "[Descripción concisa de la tarea]" \
+  --body "## Objetivo
+Qué se va a implementar/modificar.
+
+## Pasos
+1. Paso 1
+2. Paso 2
+
+## Archivos Afectados
+- src/components/...
+
+## Criterios de Aceptación
+- [ ] Funcionalidad implementada
+- [ ] Sin errores TypeScript
+- [ ] Probado localmente
+
+## Related
+Parte de #[número-issue-fase]"
+```
+
+**Anotar el número de issue** (ejemplo: #23)
+
+#### 3. Crear Rama Feature
+
+```bash
+# Crear y cambiar a nueva rama
+git checkout -b feature/23-descripcion-corta
+
+# Ejemplo real:
+git checkout -b feature/23-create-dashboard-layout
+
+# Verificar rama actual
+git branch
+```
+
+**Nomenclatura de ramas:**
+
+- Prefijo: `feature/`
+- Número de issue: `23`
+- Descripción corta: `descripcion-corta`
+- Todo en minúsculas con guiones `-`
+
+#### 4. Desarrollar la Tarea
+
+```bash
+# Desarrollar normalmente...
+# Editar archivos, crear componentes, etc.
+
+# Ver archivos modificados
+git status
+
+# Ver diferencias
+git diff
+```
+
+#### 5. Hacer Commit
+
+```bash
+# Agregar archivos al staging
+git add .
+
+# O agregar archivos específicos
+git add src/components/Dashboard.tsx
+
+# Commit con mensaje descriptivo
+git commit -m "feat: create dashboard layout with header and sidebar"
+
+# Ver historial
+git log --oneline
+```
+
+**Convenciones de Commits** (Conventional Commits):
+
+```
+feat: nueva funcionalidad
+fix: corrección de bug
+docs: cambios en documentación
+style: formato de código (sin cambio lógico)
+refactor: refactorización
+test: agregar o modificar tests
+chore: tareas de mantenimiento
+
+Ejemplos:
+feat: add transaction form component
+fix: correct currency conversion logic
+docs: update README with installation steps
+refactor: optimize transaction list rendering
+```
+
+#### 6. Push de la Rama
+
+```bash
+# Primera vez (crear rama en remoto)
+git push -u origin feature/23-create-dashboard-layout
+
+# Pushes subsecuentes (si haces más commits)
+git push
+```
+
+#### 7. Crear Pull Request
+
+**Opción A - GitHub CLI (recomendado):**
+
+```bash
+gh pr create \
+  --base develop \
+  --head feature/23-create-dashboard-layout \
+  --title "Create dashboard layout with header and sidebar" \
+  --body "## Cambios
+- Implementado layout principal con Chakra UI Grid
+- Agregado Header component
+- Agregado Sidebar component
+- Implementado responsive design
+
+## Testing
+- ✅ Probado en desktop
+- ✅ Probado en mobile
+- ✅ Sin errores de TypeScript
+
+## Screenshots
+[Agregar capturas si es relevante]
+
+Closes #23
+Related to #15"
+```
+
+**Opción B - GitHub Web:**
+
+1. Ve a tu repositorio en GitHub
+2. Verás banner de "Compare & pull request"
+3. Click en el banner
+4. Base: `develop` ← Head: `feature/23-...`
+5. Completa título y descripción
+6. Asigna el PR a ti mismo
+7. Agrega labels si quieres (enhancement, bug, etc.)
+8. Click "Create pull request"
+
+#### 8. Code Review
+
+**Auto-Review Checklist:**
+
+```markdown
+## Funcionalidad
+
+- [ ] El código hace lo que dice que hace
+- [ ] La aplicación corre sin errores
+- [ ] No hay warnings en consola
+- [ ] TypeScript compila sin errores
+
+## Calidad de Código
+
+- [ ] Código legible y bien organizado
+- [ ] Nombres de variables/funciones descriptivos
+- [ ] No hay código comentado innecesario
+- [ ] No hay console.logs de debug
+- [ ] Imports ordenados correctamente
+
+## Git
+
+- [ ] Commits con mensajes descriptivos
+- [ ] No hay archivos innecesarios
+- [ ] El PR está asociado al issue correcto
+
+## Testing
+
+- [ ] Funcionalidad probada en navegador
+- [ ] Probado en diferentes tamaños de pantalla
+- [ ] No rompe funcionalidad existente
+```
+
+**Probar PR localmente (opcional):**
+
+```bash
+# Hacer checkout del PR para probarlo
+gh pr checkout 45
+
+# Probar la aplicación
+pnpm dev
+
+# Volver a develop cuando termines
+git checkout develop
+```
+
+#### 9. Aprobar y Merge del PR
+
+**Si todo está bien:**
+
+```bash
+# Merge con squash (recomendado - mantiene historial limpio)
+gh pr merge 45 --squash
+
+# O merge normal
+gh pr merge 45 --merge
+
+# Eliminar rama local
+git checkout develop
+git pull origin develop
+git branch -d feature/23-create-dashboard-layout
+```
+
+**GitHub automáticamente:**
+
+- Cierra el PR
+- Elimina la rama remota (si está configurado)
+- Cierra el issue (si pusiste "Closes #23" en el PR)
+
+#### 10. Cerrar Issue (si no se cerró automático)
+
+```bash
+gh issue close 23
+```
+
+---
+
+### FIN DE FASE
+
+#### 1. Verificar que Todas las Tareas Están Mergeadas
+
+```bash
+# Ir a develop y actualizar
+git checkout develop
+git pull origin develop
+
+# Ver últimos commits
+git log --oneline -20
+
+# Verificar que están todos los features de la fase
+```
+
+#### 2. Verificar Build
+
+```bash
+# Instalar dependencias (si cambiaron)
+pnpm install
+
+# Build de producción
+pnpm build
+
+# Si build es exitoso, probar
+pnpm start
+```
+
+Abrir http://localhost:3000 y verificar que todo funciona.
+
+#### 3. Crear PR develop → main
+
+```bash
+gh pr create \
+  --base main \
+  --head develop \
+  --title "FASE [N]: [Nombre de la fase]" \
+  --body "## Resumen
+Descripción general de lo logrado en esta fase.
+
+## Tareas Completadas
+- [x] Tarea 1 (#23)
+- [x] Tarea 2 (#24)
+- [x] Tarea 3 (#25)
+...
+
+## Testing
+- ✅ Build exitoso
+- ✅ Aplicación funcional
+- ✅ Sin errores de TypeScript
+- ✅ Probado en desarrollo local
+
+## Next Steps
+Siguiente fase a desarrollar...
+
+Closes #15"
+```
+
+#### 4. ⚠️ DETENER DESARROLLO
+
+**No continúes con la siguiente fase.**
+
+El PR `develop → main` requiere revisión manual.
+
+#### 5. 📢 NOTIFICAR
+
+Informa que la fase está completa:
+
+```
+FASE [N] completada y lista para revisión.
+PR #[número] creado: develop → main
+Esperando aprobación para continuar.
+```
+
+#### 6. ⏸️ ESPERAR APROBACIÓN
+
+El usuario revisará:
+
+- El código en GitHub
+- La aplicación en preview de Vercel
+- Que todas las tareas se completaron
+
+#### 7. Después de Aprobación - Merge
+
+Una vez aprobado:
+
+```bash
+# Merge del PR
+gh pr merge [número-pr] --merge
+
+# Actualizar develop
+git checkout develop
+git pull origin develop
+
+# Actualizar main localmente
+git checkout main
+git pull origin main
+
+# Verificar que están sincronizados
+git log --oneline -5
+
+# Volver a develop para siguiente fase
+git checkout develop
+```
+
+#### 8. Cerrar Issue de Fase
+
+```bash
+gh issue close 15
+```
+
+---
+
+## 🛠️ Comandos de Referencia Rápida
+
+### Git Básico
+
+```bash
+# Ver estado
+git status
+
+# Ver ramas
+git branch
+git branch -a  # Incluye remotas
+
+# Cambiar de rama
+git checkout nombre-rama
+
+# Crear y cambiar a nueva rama
+git checkout -b nombre-nueva-rama
+
+# Ver diferencias
+git diff
+git diff archivo.ts
+
+# Ver historial
+git log
+git log --oneline
+git log --oneline --graph --all
+
+# Deshacer cambios (archivo no staged)
+git checkout -- archivo.ts
+
+# Deshacer cambios (archivo staged)
+git reset HEAD archivo.ts
+git checkout -- archivo.ts
+
+# Actualizar desde remoto
+git fetch origin
+git pull origin develop
+```
+
+### GitHub CLI
+
+```bash
+# Issues
+gh issue list
+gh issue view [número]
+gh issue create
+gh issue close [número]
+
+# Pull Requests
+gh pr list
+gh pr view [número]
+gh pr create
+gh pr checkout [número]
+gh pr merge [número]
+gh pr close [número]
+
+# Repositorio
+gh repo view
+gh browse  # Abrir repo en navegador
+```
+
+### pnpm (contexto Next.js)
+
+```bash
+pnpm install              # Instalar dependencias
+pnpm dev                  # Dev server
+pnpm build                # Build de producción
+pnpm start                # Server de producción
+pnpm lint                 # Linter
+pnpm type-check           # Verificar TypeScript
+```
+
+---
+
+## 🔧 Resolución de Problemas Comunes
+
+### Problema 1: Merge Conflicts
+
+Cuando hay conflictos al hacer merge o pull:
+
+```bash
+# Ver archivos en conflicto
+git status
+
+# Editar los archivos y resolver conflictos manualmente
+# Buscar marcadores: <<<<<<, ======, >>>>>>
+
+# Después de resolver
+git add archivo-resuelto.ts
+git commit -m "resolve merge conflicts"
+git push
+```
+
+### Problema 2: Olvidaste crear rama desde develop
+
+```bash
+# Si ya hiciste commits en develop por error
+git checkout -b feature/nueva-rama
+
+# Regresar develop al estado remoto
+git checkout develop
+git reset --hard origin/develop
+
+# Ahora tus commits están en feature/nueva-rama
+git checkout feature/nueva-rama
+```
+
+### Problema 3: Necesitas actualizar tu rama con cambios de develop
+
+```bash
+# Estando en tu rama feature
+git fetch origin
+
+# Opción A: Merge (crea commit de merge)
+git merge origin/develop
+
+# Opción B: Rebase (historial más limpio)
+git rebase origin/develop
+
+# Si hay conflictos, resuélvelos y:
+git add .
+git rebase --continue
+
+# Push (forzado si usaste rebase)
+git push --force-with-lease
+```
+
+### Problema 4: Commit con mensaje incorrecto
+
+```bash
+# Último commit (antes de push)
+git commit --amend -m "mensaje correcto"
+
+# Si ya hiciste push
+git commit --amend -m "mensaje correcto"
+git push --force-with-lease
+```
+
+### Problema 5: Olvidaste agregar archivos al último commit
+
+```bash
+# Agregar archivos
+git add archivo-olvidado.ts
+
+# Agregar al último commit
+git commit --amend --no-edit
+
+# Push
+git push --force-with-lease
+```
+
+### Problema 6: Quieres deshacer el último commit (local)
+
+```bash
+# Mantener cambios en working directory
+git reset --soft HEAD~1
+
+# Descartar cambios completamente
+git reset --hard HEAD~1
+```
+
+---
+
+## 📊 Ejemplo Completo de Flujo
+
+### Caso: FASE 5, Tarea 5.3 - Configurar Tema de Chakra UI
+
+```bash
+# 1. Estar en develop actualizado
+git checkout develop
+git pull origin develop
+
+# 2. Crear issue de tarea
+gh issue create \
+  --title "Configurar tema personalizado de Chakra UI" \
+  --body "..."
+# Resultado: Issue #34 creado
+
+# 3. Crear rama
+git checkout -b feature/34-chakra-ui-theme
+
+# 4. Desarrollar
+# ... crear src/theme/index.ts
+# ... modificar src/app/providers.tsx
+
+# 5. Commit
+git add .
+git commit -m "feat: configure custom Chakra UI theme with colors and fonts"
+
+# 6. Push
+git push -u origin feature/34-chakra-ui-theme
+
+# 7. Crear PR
+gh pr create \
+  --base develop \
+  --title "Configure custom Chakra UI theme" \
+  --body "Closes #34"
+
+# 8. Auto-review
+# ... verificar en navegador
+# ... verificar TypeScript
+
+# 9. Merge
+gh pr merge 45 --squash
+
+# 10. Cleanup
+git checkout develop
+git pull origin develop
+git branch -d feature/34-chakra-ui-theme
+
+# Resultado: Tarea completada ✅
+```
+
+---
+
+## 🎯 Best Practices
+
+### ✅ HACER:
+
+- ✅ Commits frecuentes con mensajes descriptivos
+- ✅ Una rama por tarea (no mezclar tareas)
+- ✅ PRs pequeños y enfocados
+- ✅ Probar antes de push
+- ✅ Revisar tu propio código antes de crear PR
+- ✅ Mantener develop siempre funcional
+- ✅ Actualizar develop antes de crear nueva rama
+- ✅ Cerrar issues al completar tareas
+
+### ❌ NO HACER:
+
+- ❌ Trabajar directamente en develop o main
+- ❌ PRs gigantes con múltiples funcionalidades
+- ❌ Commits con mensajes vagos ("fix", "update", "wip")
+- ❌ Push de código que no compila
+- ❌ Dejar console.logs en el código
+- ❌ Mezclar múltiples tareas en un PR
+- ❌ Hacer force push a develop o main
+
+---
+
+## 📝 Template de Mensaje de Commit
+
+```
+<tipo>: <descripción corta>
+
+[Opcional] Descripción larga explicando el por qué
+y cualquier contexto relevante.
+
+[Opcional] Refs: #issue-number
+```
+
+**Tipos:**
+
+- `feat`: Nueva funcionalidad
+- `fix`: Corrección de bug
+- `docs`: Documentación
+- `style`: Formato (sin cambio de código)
+- `refactor`: Refactorización
+- `test`: Tests
+- `chore`: Mantenimiento
+
+**Ejemplos:**
+
+```
+feat: add currency conversion selector
+
+Implements dropdown to select between COP, USD, BOB.
+Conversion rates are fetched from exchange_rates table.
+
+Refs: #45
+```
+
+```
+fix: correct transaction list pagination
+
+Fixed off-by-one error causing last page to show incorrect items.
+
+Closes #52
+```
+
+---
+
+## 🔐 Seguridad
+
+### .gitignore Esencial
+
+Asegúrate de que `.gitignore` incluye:
+
+```gitignore
+# Dependencies
+node_modules/
+
+# Build output
+.next/
+out/
+dist/
+build/
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+.env.production
+
+# Credentials
+CREDENTIALS.md
+secrets.json
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Editor
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Testing
+coverage/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Misc
+*.pem
+```
+
+### ⚠️ NUNCA commitear:
+
+- ❌ Archivos `.env` con credenciales reales
+- ❌ API keys
+- ❌ Passwords
+- ❌ Tokens de autenticación
+- ❌ Archivos de credenciales
+
+---
+
+## 📞 Ayuda Adicional
+
+### Recursos:
+
+- **Git Docs**: https://git-scm.com/doc
+- **GitHub CLI Docs**: https://cli.github.com/manual/
+- **GitHub Flow**: https://guides.github.com/introduction/flow/
+- **Conventional Commits**: https://www.conventionalcommits.org/
+
+### Comandos de Ayuda:
+
+```bash
+git help
+gh help
+git <comando> --help
+gh <comando> --help
+```
+
+---
+
+**¡Éxito con el flujo de trabajo! 🚀**
+
+Recuerda: Un flujo de trabajo limpio y organizado hace el desarrollo más fácil y el código más mantenible.

--- a/catalog/rules/github-flow/manifest.json
+++ b/catalog/rules/github-flow/manifest.json
@@ -1,0 +1,15 @@
+{
+  "id": "github-flow",
+  "name": "GitHub Flow",
+  "description": "Flujo de trabajo completo con Git y GitHub: feature branches, PRs, code review y merge strategy",
+  "category": "rules",
+  "tags": ["git", "github", "workflow", "branching"],
+  "deps": {
+    "dependencies": [],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/github-flow.md", "dest": "rules/github-flow.md" }
+  ],
+  "docsUrl": "https://sanghel-playbook.vercel.app/docs/catalog/rules/github-flow"
+}

--- a/catalog/rules/index.json
+++ b/catalog/rules/index.json
@@ -1,0 +1,5 @@
+{
+  "category": "rules",
+  "label": "Rules & Guides",
+  "items": ["github-flow", "deploy-guide"]
+}

--- a/docs/superpowers/plans/2026-05-05-cli-tui-installer.md
+++ b/docs/superpowers/plans/2026-05-05-cli-tui-installer.md
@@ -291,7 +291,7 @@ git commit -m "feat(cli): tipos compartidos (CatalogIndex, ManifestItem, etc.)"
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { fetchJson, fetchText, fetchCatalogIndex, fetchCategoryIndex, fetchManifest, fetchFile } from './fetcher.js'
 
-const BASE = 'https://raw.githubusercontent.com/sanghelgonzalez/sanghel-playbook/main'
+const BASE = 'https://raw.githubusercontent.com/Sanghel/sanghel-playbook/main'
 
 global.fetch = vi.fn()
 
@@ -413,7 +413,7 @@ Expected: FAIL — "Cannot find module './fetcher.js'"
 ```typescript
 import type { CatalogIndex, CategoryIndex, ManifestItem } from '../types.js'
 
-const BASE_URL = 'https://raw.githubusercontent.com/sanghelgonzalez/sanghel-playbook/main'
+const BASE_URL = 'https://raw.githubusercontent.com/Sanghel/sanghel-playbook/main'
 
 export async function fetchJson<T>(path: string): Promise<T> {
   const res = await fetch(`${BASE_URL}/${path}`)

--- a/docs/superpowers/plans/2026-05-05-cli-tui-installer.md
+++ b/docs/superpowers/plans/2026-05-05-cli-tui-installer.md
@@ -291,7 +291,7 @@ git commit -m "feat(cli): tipos compartidos (CatalogIndex, ManifestItem, etc.)"
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { fetchJson, fetchText, fetchCatalogIndex, fetchCategoryIndex, fetchManifest, fetchFile } from './fetcher.js'
 
-const BASE = 'https://raw.githubusercontent.com/Sanghel/sanghel-playbook/main'
+const BASE = 'https://raw.githubusercontent.com/sanghelgonzalez/sanghel-playbook/main'
 
 global.fetch = vi.fn()
 
@@ -413,7 +413,7 @@ Expected: FAIL — "Cannot find module './fetcher.js'"
 ```typescript
 import type { CatalogIndex, CategoryIndex, ManifestItem } from '../types.js'
 
-const BASE_URL = 'https://raw.githubusercontent.com/Sanghel/sanghel-playbook/main'
+const BASE_URL = 'https://raw.githubusercontent.com/sanghelgonzalez/sanghel-playbook/main'
 
 export async function fetchJson<T>(path: string): Promise<T> {
   const res = await fetch(`${BASE_URL}/${path}`)

--- a/docs/superpowers/plans/2026-05-05-cli-tui-installer.md
+++ b/docs/superpowers/plans/2026-05-05-cli-tui-installer.md
@@ -1,0 +1,1736 @@
+# CLI/TUI Installer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Transformar sanghel-playbook en un monorepo con un CLI/TUI público (`npx sanghel-playbook`) que permite instalar patrones del catálogo o scaffoldear nuevos proyectos, leyendo el contenido desde este mismo repo en GitHub.
+
+**Architecture:** Monorepo con `packages/cli` (TUI con Ink 5 + React 18, TypeScript ESM) y `catalog/` (manifests JSON + archivos fuente). El CLI fetcha contenido desde GitHub raw en runtime. El site Next.js no cambia estructuralmente.
+
+**Tech Stack:** Ink 5, React 18, TypeScript 5 strict, tsup (build), vitest (tests), native fetch (Node ≥18)
+
+---
+
+## Mapa de archivos
+
+| Archivo | Estado | Responsabilidad |
+|---|---|---|
+| `package.json` (raíz) | Modificar | Añadir `workspaces: ["packages/*"]` |
+| `packages/cli/package.json` | Crear | Metadata del paquete npm, bin entry, deps |
+| `packages/cli/tsconfig.json` | Crear | TypeScript config (ESM, React JSX) |
+| `packages/cli/tsup.config.ts` | Crear | Build config (ESM, shebang) |
+| `packages/cli/vitest.config.ts` | Crear | Config de tests |
+| `packages/cli/src/types.ts` | Crear | Interfaces compartidas (CatalogIndex, ManifestItem, etc.) |
+| `packages/cli/src/lib/fetcher.ts` | Crear | Fetch de JSON y archivos desde GitHub raw |
+| `packages/cli/src/lib/package-manager.ts` | Crear | Detectar pnpm/yarn/npm, generar comandos install |
+| `packages/cli/src/lib/installer.ts` | Crear | Copiar archivos al cwd del usuario |
+| `packages/cli/src/lib/scaffolder.ts` | Crear | Correr create-next-app, create vite, create astro |
+| `packages/cli/src/commands/add.ts` | Crear | Lógica de flujo "añadir a proyecto" |
+| `packages/cli/src/commands/create.ts` | Crear | Lógica de flujo "crear proyecto" |
+| `packages/cli/src/ui/MainMenu.tsx` | Crear | Primera pantalla: crear / añadir |
+| `packages/cli/src/ui/StackMenu.tsx` | Crear | Selección de stack base para proyecto nuevo |
+| `packages/cli/src/ui/CategoryMenu.tsx` | Crear | Selección de categoría del catálogo |
+| `packages/cli/src/ui/ItemSelect.tsx` | Crear | Multi-select de items con espacio |
+| `packages/cli/src/ui/InstallProgress.tsx` | Crear | Pantalla de progreso de instalación |
+| `packages/cli/src/index.tsx` | Crear | Entry point: App state machine + render |
+| `packages/cli/src/lib/fetcher.test.ts` | Crear | Tests de fetcher |
+| `packages/cli/src/lib/package-manager.test.ts` | Crear | Tests de package-manager |
+| `packages/cli/src/lib/installer.test.ts` | Crear | Tests de installer |
+| `packages/cli/src/lib/scaffolder.test.ts` | Crear | Tests de scaffolder |
+| `catalog/index.json` | Crear | Lista de categorías del catálogo |
+| `catalog/react/index.json` | Crear | Items disponibles en React |
+| `catalog/nextjs/index.json` | Crear | Items disponibles en Next.js |
+| `catalog/astro/index.json` | Crear | Items disponibles en Astro |
+| `catalog/rules/index.json` | Crear | Items disponibles en Rules |
+| `catalog/rules/github-flow/manifest.json` | Crear | Manifest del github-flow |
+| `catalog/rules/github-flow/files/github-flow.md` | Crear | Archivo fuente (copia de rules/) |
+| `catalog/rules/deploy-guide/manifest.json` | Crear | Manifest del deploy-guide |
+| `catalog/rules/deploy-guide/files/deploy-guide.md` | Crear | Archivo fuente (copia de rules/) |
+| `src/content/docs/getting-started.mdx` | Modificar | Explicar el CLI |
+
+---
+
+## Task 1: Monorepo setup
+
+**Files:**
+- Modify: `package.json` (raíz)
+- Create: `packages/cli/package.json`
+- Create: `packages/cli/tsconfig.json`
+- Create: `packages/cli/tsup.config.ts`
+- Create: `packages/cli/vitest.config.ts`
+
+- [ ] **Step 1: Añadir workspaces al package.json raíz**
+
+Editar `package.json` (raíz) — añadir la clave `workspaces` y eliminar `"private": true` solo si quieres publicar la raíz (mantenerlo está bien):
+
+```json
+{
+  "name": "sanghel-playbook",
+  "version": "0.1.0",
+  "private": true,
+  "workspaces": ["packages/*"],
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "@tailwindcss/typography": "^0.5.19",
+    "fuse.js": "^7.3.0",
+    "github-slugger": "^2.0.0",
+    "gray-matter": "^4.0.3",
+    "next": "16.2.4",
+    "next-mdx-remote": "^6.0.0",
+    "next-themes": "^0.4.6",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
+    "rehype-pretty-code": "^0.14.3",
+    "rehype-slug": "^6.0.0",
+    "shiki": "^4.0.2"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@types/mdx": "^2.0.13",
+    "@types/node": "^20",
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "eslint": "^9",
+    "eslint-config-next": "16.2.4",
+    "tailwindcss": "^4",
+    "typescript": "^5"
+  }
+}
+```
+
+- [ ] **Step 2: Crear packages/cli/package.json**
+
+```bash
+mkdir -p packages/cli/src/ui packages/cli/src/lib packages/cli/src/commands
+```
+
+Crear `packages/cli/package.json`:
+
+```json
+{
+  "name": "sanghel-playbook",
+  "version": "0.1.0",
+  "description": "CLI/TUI para instalar patrones y scaffoldear proyectos desde el sanghel-playbook",
+  "type": "module",
+  "bin": {
+    "sanghel-playbook": "./dist/index.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "ink": "^5.2.0",
+    "ink-spinner": "^5.0.0",
+    "react": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18",
+    "tsup": "^8",
+    "typescript": "^5",
+    "vitest": "^3"
+  },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  }
+}
+```
+
+- [ ] **Step 3: Crear packages/cli/tsconfig.json**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}
+```
+
+- [ ] **Step 4: Crear packages/cli/tsup.config.ts**
+
+```typescript
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.tsx'],
+  format: ['esm'],
+  target: 'node18',
+  outDir: 'dist',
+  banner: {
+    js: '#!/usr/bin/env node',
+  },
+  jsx: 'transform',
+  jsxImportSource: 'react',
+  clean: true,
+  sourcemap: false,
+})
+```
+
+- [ ] **Step 5: Crear packages/cli/vitest.config.ts**
+
+```typescript
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+})
+```
+
+- [ ] **Step 6: Instalar dependencias del workspace**
+
+```bash
+cd packages/cli && pnpm install
+```
+
+Expected: se instalan ink, react, ink-spinner y devDependencies sin errores.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json packages/cli/
+git commit -m "chore: setup monorepo con packages/cli (Ink TUI)"
+```
+
+---
+
+## Task 2: TypeScript types
+
+**Files:**
+- Create: `packages/cli/src/types.ts`
+
+- [ ] **Step 1: Crear packages/cli/src/types.ts**
+
+```typescript
+export interface CatalogIndex {
+  categories: CategoryRef[]
+}
+
+export interface CategoryRef {
+  id: string
+  label: string
+  indexUrl: string
+}
+
+export interface CategoryIndex {
+  category: string
+  label: string
+  items: string[]
+}
+
+export interface ManifestItem {
+  id: string
+  name: string
+  description: string
+  category: string
+  tags: string[]
+  deps: {
+    dependencies: string[]
+    devDependencies: string[]
+  }
+  files: FileEntry[]
+  docsUrl: string
+}
+
+export interface FileEntry {
+  src: string
+  dest: string
+}
+
+export interface InstallResult {
+  path: string
+  skipped: boolean
+}
+
+export interface InstallStep {
+  label: string
+  status: 'pending' | 'running' | 'done' | 'skipped' | 'error'
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/cli/src/types.ts
+git commit -m "feat(cli): tipos compartidos (CatalogIndex, ManifestItem, etc.)"
+```
+
+---
+
+## Task 3: lib/fetcher.ts (TDD)
+
+**Files:**
+- Create: `packages/cli/src/lib/fetcher.ts`
+- Create: `packages/cli/src/lib/fetcher.test.ts`
+
+- [ ] **Step 1: Escribir los tests en fetcher.test.ts**
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchJson, fetchText, fetchCatalogIndex, fetchCategoryIndex, fetchManifest, fetchFile } from './fetcher.js'
+
+const BASE = 'https://raw.githubusercontent.com/Sanghel/sanghel-playbook/main'
+
+global.fetch = vi.fn()
+
+describe('fetchJson', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('fetches and parses JSON from the correct URL', async () => {
+    const mockData = { categories: [] }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
+    } as Response)
+
+    const result = await fetchJson('catalog/index.json')
+
+    expect(fetch).toHaveBeenCalledWith(`${BASE}/catalog/index.json`)
+    expect(result).toEqual(mockData)
+  })
+
+  it('throws when response is not ok', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 404 } as Response)
+
+    await expect(fetchJson('catalog/index.json')).rejects.toThrow(
+      'Failed to fetch catalog/index.json: 404'
+    )
+  })
+})
+
+describe('fetchText', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('fetches text content from the correct URL', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('file content here'),
+    } as unknown as Response)
+
+    const result = await fetchText('catalog/rules/github-flow/files/github-flow.md')
+
+    expect(fetch).toHaveBeenCalledWith(`${BASE}/catalog/rules/github-flow/files/github-flow.md`)
+    expect(result).toBe('file content here')
+  })
+})
+
+describe('fetchCatalogIndex', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('fetches catalog/index.json', async () => {
+    const mockIndex = { categories: [{ id: 'react', label: 'React', indexUrl: 'catalog/react/index.json' }] }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockIndex),
+    } as Response)
+
+    const result = await fetchCatalogIndex()
+    expect(fetch).toHaveBeenCalledWith(`${BASE}/catalog/index.json`)
+    expect(result.categories).toHaveLength(1)
+  })
+})
+
+describe('fetchCategoryIndex', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('fetches catalog/{categoryId}/index.json', async () => {
+    const mockCatIndex = { category: 'react', label: 'React', items: ['zod-form'] }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockCatIndex),
+    } as Response)
+
+    const result = await fetchCategoryIndex('react')
+    expect(fetch).toHaveBeenCalledWith(`${BASE}/catalog/react/index.json`)
+    expect(result.items).toEqual(['zod-form'])
+  })
+})
+
+describe('fetchManifest', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('fetches catalog/{categoryId}/{itemId}/manifest.json', async () => {
+    const mockManifest = { id: 'zod-form', name: 'Zod Form', description: '', category: 'react', tags: [], deps: { dependencies: [], devDependencies: [] }, files: [], docsUrl: '' }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockManifest),
+    } as Response)
+
+    const result = await fetchManifest('react', 'zod-form')
+    expect(fetch).toHaveBeenCalledWith(`${BASE}/catalog/react/zod-form/manifest.json`)
+    expect(result.id).toBe('zod-form')
+  })
+})
+
+describe('fetchFile', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('fetches catalog/{categoryId}/{itemId}/files/{filename}', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('export const x = 1'),
+    } as unknown as Response)
+
+    const result = await fetchFile('react', 'zod-form', 'useZodForm.ts')
+    expect(fetch).toHaveBeenCalledWith(`${BASE}/catalog/react/zod-form/files/useZodForm.ts`)
+    expect(result).toBe('export const x = 1')
+  })
+})
+```
+
+- [ ] **Step 2: Correr tests — deben fallar**
+
+```bash
+cd packages/cli && pnpm test
+```
+
+Expected: FAIL — "Cannot find module './fetcher.js'"
+
+- [ ] **Step 3: Implementar packages/cli/src/lib/fetcher.ts**
+
+```typescript
+import type { CatalogIndex, CategoryIndex, ManifestItem } from '../types.js'
+
+const BASE_URL = 'https://raw.githubusercontent.com/Sanghel/sanghel-playbook/main'
+
+export async function fetchJson<T>(path: string): Promise<T> {
+  const res = await fetch(`${BASE_URL}/${path}`)
+  if (!res.ok) throw new Error(`Failed to fetch ${path}: ${res.status}`)
+  return res.json() as Promise<T>
+}
+
+export async function fetchText(path: string): Promise<string> {
+  const res = await fetch(`${BASE_URL}/${path}`)
+  if (!res.ok) throw new Error(`Failed to fetch ${path}: ${res.status}`)
+  return res.text()
+}
+
+export async function fetchCatalogIndex(): Promise<CatalogIndex> {
+  return fetchJson<CatalogIndex>('catalog/index.json')
+}
+
+export async function fetchCategoryIndex(categoryId: string): Promise<CategoryIndex> {
+  return fetchJson<CategoryIndex>(`catalog/${categoryId}/index.json`)
+}
+
+export async function fetchManifest(categoryId: string, itemId: string): Promise<ManifestItem> {
+  return fetchJson<ManifestItem>(`catalog/${categoryId}/${itemId}/manifest.json`)
+}
+
+export async function fetchFile(categoryId: string, itemId: string, filename: string): Promise<string> {
+  return fetchText(`catalog/${categoryId}/${itemId}/files/${filename}`)
+}
+```
+
+- [ ] **Step 4: Correr tests — deben pasar**
+
+```bash
+cd packages/cli && pnpm test
+```
+
+Expected: PASS — 8 tests passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/lib/fetcher.ts packages/cli/src/lib/fetcher.test.ts
+git commit -m "feat(cli): lib/fetcher — fetch de JSON y archivos desde GitHub raw"
+```
+
+---
+
+## Task 4: lib/package-manager.ts (TDD)
+
+**Files:**
+- Create: `packages/cli/src/lib/package-manager.ts`
+- Create: `packages/cli/src/lib/package-manager.test.ts`
+
+- [ ] **Step 1: Escribir los tests en package-manager.test.ts**
+
+```typescript
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { existsSync } from 'fs'
+import { detectPackageManager, getInstallCommand } from './package-manager.js'
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+}))
+
+describe('detectPackageManager', () => {
+  afterEach(() => vi.resetAllMocks())
+
+  it('detecta pnpm por pnpm-lock.yaml', () => {
+    vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith('pnpm-lock.yaml'))
+    expect(detectPackageManager('/fake/dir')).toBe('pnpm')
+  })
+
+  it('detecta yarn por yarn.lock', () => {
+    vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith('yarn.lock'))
+    expect(detectPackageManager('/fake/dir')).toBe('yarn')
+  })
+
+  it('detecta npm por package-lock.json', () => {
+    vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith('package-lock.json'))
+    expect(detectPackageManager('/fake/dir')).toBe('npm')
+  })
+
+  it('devuelve null si no hay lockfile', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    expect(detectPackageManager('/fake/dir')).toBeNull()
+  })
+
+  it('prioriza pnpm sobre los demás', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    expect(detectPackageManager('/fake/dir')).toBe('pnpm')
+  })
+})
+
+describe('getInstallCommand', () => {
+  it('pnpm: pnpm add deps', () => {
+    expect(getInstallCommand('pnpm', ['zod', 'react-hook-form'])).toBe('pnpm add zod react-hook-form')
+  })
+
+  it('yarn: yarn add deps', () => {
+    expect(getInstallCommand('yarn', ['zod'])).toBe('yarn add zod')
+  })
+
+  it('npm: npm install deps', () => {
+    expect(getInstallCommand('npm', ['zod'])).toBe('npm install zod')
+  })
+
+  it('pnpm devDeps: pnpm add -D', () => {
+    expect(getInstallCommand('pnpm', ['vitest'], true)).toBe('pnpm add -D vitest')
+  })
+
+  it('yarn devDeps: yarn add -D', () => {
+    expect(getInstallCommand('yarn', ['vitest'], true)).toBe('yarn add -D vitest')
+  })
+
+  it('npm devDeps: npm install --save-dev', () => {
+    expect(getInstallCommand('npm', ['vitest'], true)).toBe('npm install --save-dev vitest')
+  })
+})
+```
+
+- [ ] **Step 2: Correr tests — deben fallar**
+
+```bash
+cd packages/cli && pnpm test
+```
+
+Expected: FAIL — "Cannot find module './package-manager.js'"
+
+- [ ] **Step 3: Implementar packages/cli/src/lib/package-manager.ts**
+
+```typescript
+import { existsSync } from 'fs'
+import { join } from 'path'
+
+export type PackageManager = 'pnpm' | 'yarn' | 'npm'
+
+export function detectPackageManager(cwd: string = process.cwd()): PackageManager | null {
+  if (existsSync(join(cwd, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (existsSync(join(cwd, 'yarn.lock'))) return 'yarn'
+  if (existsSync(join(cwd, 'package-lock.json'))) return 'npm'
+  return null
+}
+
+export function getInstallCommand(pm: PackageManager, deps: string[], dev = false): string {
+  const depStr = deps.join(' ')
+  if (pm === 'pnpm') return dev ? `pnpm add -D ${depStr}` : `pnpm add ${depStr}`
+  if (pm === 'yarn') return dev ? `yarn add -D ${depStr}` : `yarn add ${depStr}`
+  return dev ? `npm install --save-dev ${depStr}` : `npm install ${depStr}`
+}
+```
+
+- [ ] **Step 4: Correr tests — deben pasar**
+
+```bash
+cd packages/cli && pnpm test
+```
+
+Expected: PASS — todos los tests de package-manager pasan
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/lib/package-manager.ts packages/cli/src/lib/package-manager.test.ts
+git commit -m "feat(cli): lib/package-manager — detectar pnpm/yarn/npm y generar comandos"
+```
+
+---
+
+## Task 5: lib/installer.ts (TDD)
+
+**Files:**
+- Create: `packages/cli/src/lib/installer.ts`
+- Create: `packages/cli/src/lib/installer.test.ts`
+
+- [ ] **Step 1: Escribir los tests en installer.test.ts**
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { installFiles } from './installer.js'
+import * as fetcher from './fetcher.js'
+import type { ManifestItem } from '../types.js'
+
+vi.mock('./fetcher.js')
+
+const mockManifest: ManifestItem = {
+  id: 'zod-form',
+  name: 'Zod Form Pattern',
+  description: 'Test',
+  category: 'react',
+  tags: [],
+  deps: { dependencies: ['zod'], devDependencies: [] },
+  files: [
+    { src: 'files/useZodForm.ts', dest: 'src/hooks/useZodForm.ts' },
+  ],
+  docsUrl: 'https://example.com',
+}
+
+describe('installFiles', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'installer-test-'))
+    vi.mocked(fetcher.fetchFile).mockResolvedValue('export const useZodForm = () => ({})')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true })
+    vi.resetAllMocks()
+  })
+
+  it('escribe el archivo en el destino correcto', async () => {
+    const results = await installFiles(mockManifest, tmpDir)
+
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe('src/hooks/useZodForm.ts')
+    expect(results[0].skipped).toBe(false)
+    expect(existsSync(join(tmpDir, 'src/hooks/useZodForm.ts'))).toBe(true)
+    expect(readFileSync(join(tmpDir, 'src/hooks/useZodForm.ts'), 'utf-8')).toBe('export const useZodForm = () => ({})')
+  })
+
+  it('crea directorios intermedios si no existen', async () => {
+    await installFiles(mockManifest, tmpDir)
+    expect(existsSync(join(tmpDir, 'src/hooks'))).toBe(true)
+  })
+
+  it('llama a fetchFile con los parámetros correctos', async () => {
+    await installFiles(mockManifest, tmpDir)
+    expect(fetcher.fetchFile).toHaveBeenCalledWith('react', 'zod-form', 'useZodForm.ts')
+  })
+
+  it('marca como skipped si el archivo ya existe', async () => {
+    await installFiles(mockManifest, tmpDir)
+    const results = await installFiles(mockManifest, tmpDir)
+
+    expect(results[0].skipped).toBe(true)
+    expect(fetcher.fetchFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('instala múltiples archivos del mismo manifest', async () => {
+    const manifest: ManifestItem = {
+      ...mockManifest,
+      files: [
+        { src: 'files/useZodForm.ts', dest: 'src/hooks/useZodForm.ts' },
+        { src: 'files/FormField.tsx', dest: 'src/components/FormField.tsx' },
+      ],
+    }
+    vi.mocked(fetcher.fetchFile).mockResolvedValue('// content')
+
+    const results = await installFiles(manifest, tmpDir)
+    expect(results).toHaveLength(2)
+    expect(results.every(r => !r.skipped)).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Correr tests — deben fallar**
+
+```bash
+cd packages/cli && pnpm test
+```
+
+Expected: FAIL — "Cannot find module './installer.js'"
+
+- [ ] **Step 3: Implementar packages/cli/src/lib/installer.ts**
+
+```typescript
+import { writeFileSync, mkdirSync, existsSync } from 'fs'
+import { join, dirname, basename } from 'path'
+import { fetchFile } from './fetcher.js'
+import type { ManifestItem, InstallResult } from '../types.js'
+
+export async function installFiles(
+  manifest: ManifestItem,
+  cwd: string = process.cwd()
+): Promise<InstallResult[]> {
+  const results: InstallResult[] = []
+
+  for (const file of manifest.files) {
+    const destPath = join(cwd, file.dest)
+
+    if (existsSync(destPath)) {
+      results.push({ path: file.dest, skipped: true })
+      continue
+    }
+
+    const content = await fetchFile(manifest.category, manifest.id, basename(file.src))
+    mkdirSync(dirname(destPath), { recursive: true })
+    writeFileSync(destPath, content, 'utf-8')
+    results.push({ path: file.dest, skipped: false })
+  }
+
+  return results
+}
+```
+
+- [ ] **Step 4: Correr tests — deben pasar**
+
+```bash
+cd packages/cli && pnpm test
+```
+
+Expected: PASS — todos los tests de installer pasan
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/lib/installer.ts packages/cli/src/lib/installer.test.ts
+git commit -m "feat(cli): lib/installer — copiar archivos del catálogo al proyecto del usuario"
+```
+
+---
+
+## Task 6: lib/scaffolder.ts (TDD)
+
+**Files:**
+- Create: `packages/cli/src/lib/scaffolder.ts`
+- Create: `packages/cli/src/lib/scaffolder.test.ts`
+
+- [ ] **Step 1: Escribir los tests en scaffolder.test.ts**
+
+```typescript
+import { describe, it, expect, vi } from 'vitest'
+import { spawnSync } from 'child_process'
+import { scaffold } from './scaffolder.js'
+
+vi.mock('child_process', () => ({
+  spawnSync: vi.fn(() => ({ status: 0 })),
+}))
+
+describe('scaffold', () => {
+  it('react-vite: corre npm create vite@latest', () => {
+    scaffold('react-vite', 'my-app')
+    expect(spawnSync).toHaveBeenCalledWith(
+      'npm',
+      ['create', 'vite@latest', 'my-app'],
+      { stdio: 'inherit', shell: true }
+    )
+  })
+
+  it('nextjs: corre npx create-next-app@latest', () => {
+    scaffold('nextjs', 'my-app')
+    expect(spawnSync).toHaveBeenCalledWith(
+      'npx',
+      ['create-next-app@latest', 'my-app'],
+      { stdio: 'inherit', shell: true }
+    )
+  })
+
+  it('astro: corre npm create astro@latest', () => {
+    scaffold('astro', 'my-app')
+    expect(spawnSync).toHaveBeenCalledWith(
+      'npm',
+      ['create', 'astro@latest', 'my-app'],
+      { stdio: 'inherit', shell: true }
+    )
+  })
+
+  it('retorna true cuando status es 0', () => {
+    expect(scaffold('react-vite', 'my-app')).toBe(true)
+  })
+
+  it('retorna false cuando status es distinto de 0', () => {
+    vi.mocked(spawnSync).mockReturnValueOnce({ status: 1 } as ReturnType<typeof spawnSync>)
+    expect(scaffold('nextjs', 'my-app')).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Correr tests — deben fallar**
+
+```bash
+cd packages/cli && pnpm test
+```
+
+Expected: FAIL — "Cannot find module './scaffolder.js'"
+
+- [ ] **Step 3: Implementar packages/cli/src/lib/scaffolder.ts**
+
+```typescript
+import { spawnSync } from 'child_process'
+
+export type Stack = 'react-vite' | 'nextjs' | 'astro'
+
+type Command = [string, string[]]
+
+const COMMANDS: Record<Stack, Command> = {
+  'react-vite': ['npm', ['create', 'vite@latest']],
+  'nextjs': ['npx', ['create-next-app@latest']],
+  'astro': ['npm', ['create', 'astro@latest']],
+}
+
+export function scaffold(stack: Stack, projectName: string): boolean {
+  const [cmd, args] = COMMANDS[stack]
+  const result = spawnSync(cmd, [...args, projectName], { stdio: 'inherit', shell: true })
+  return result.status === 0
+}
+```
+
+- [ ] **Step 4: Correr todos los tests — deben pasar**
+
+```bash
+cd packages/cli && pnpm test
+```
+
+Expected: PASS — todos los tests de fetcher, package-manager, installer y scaffolder pasan.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/lib/scaffolder.ts packages/cli/src/lib/scaffolder.test.ts
+git commit -m "feat(cli): lib/scaffolder — ejecutar create-next-app/vite/astro"
+```
+
+---
+
+## Task 7: Catalog data — JSON files y migración de rules/
+
+**Files:**
+- Create: `catalog/index.json`
+- Create: `catalog/react/index.json`
+- Create: `catalog/nextjs/index.json`
+- Create: `catalog/astro/index.json`
+- Create: `catalog/rules/index.json`
+- Create: `catalog/rules/github-flow/manifest.json`
+- Create: `catalog/rules/github-flow/files/github-flow.md`
+- Create: `catalog/rules/deploy-guide/manifest.json`
+- Create: `catalog/rules/deploy-guide/files/deploy-guide.md`
+
+- [ ] **Step 1: Crear la estructura de directorios del catálogo**
+
+```bash
+mkdir -p catalog/react catalog/nextjs catalog/astro \
+         catalog/rules/github-flow/files \
+         catalog/rules/deploy-guide/files
+```
+
+- [ ] **Step 2: Crear catalog/index.json**
+
+```json
+{
+  "categories": [
+    { "id": "react", "label": "React", "indexUrl": "catalog/react/index.json" },
+    { "id": "nextjs", "label": "Next.js", "indexUrl": "catalog/nextjs/index.json" },
+    { "id": "astro", "label": "Astro", "indexUrl": "catalog/astro/index.json" },
+    { "id": "rules", "label": "Rules & Guides", "indexUrl": "catalog/rules/index.json" }
+  ]
+}
+```
+
+- [ ] **Step 3: Crear catalog/react/index.json**
+
+```json
+{
+  "category": "react",
+  "label": "React",
+  "items": []
+}
+```
+
+(Se populará con items reales en futuras PRs siguiendo el workflow de `catalog + docs en un PR`)
+
+- [ ] **Step 4: Crear catalog/nextjs/index.json**
+
+```json
+{
+  "category": "nextjs",
+  "label": "Next.js",
+  "items": []
+}
+```
+
+- [ ] **Step 5: Crear catalog/astro/index.json**
+
+```json
+{
+  "category": "astro",
+  "label": "Astro",
+  "items": []
+}
+```
+
+- [ ] **Step 6: Crear catalog/rules/index.json**
+
+```json
+{
+  "category": "rules",
+  "label": "Rules & Guides",
+  "items": ["github-flow", "deploy-guide"]
+}
+```
+
+- [ ] **Step 7: Crear catalog/rules/github-flow/manifest.json**
+
+```json
+{
+  "id": "github-flow",
+  "name": "GitHub Flow",
+  "description": "Flujo de trabajo completo con Git y GitHub: feature branches, PRs, code review y merge strategy",
+  "category": "rules",
+  "tags": ["git", "github", "workflow", "branching"],
+  "deps": {
+    "dependencies": [],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/github-flow.md", "dest": "rules/github-flow.md" }
+  ],
+  "docsUrl": "https://sanghel-playbook.vercel.app/docs/catalog/rules/github-flow"
+}
+```
+
+- [ ] **Step 8: Copiar rules/github-flow.md como catalog/rules/github-flow/files/github-flow.md**
+
+```bash
+cp rules/github-flow.md catalog/rules/github-flow/files/github-flow.md
+```
+
+- [ ] **Step 9: Crear catalog/rules/deploy-guide/manifest.json**
+
+```json
+{
+  "id": "deploy-guide",
+  "name": "Deploy Guide (Vercel)",
+  "description": "Checklist completo de deploy en Vercel: configuración, variables de entorno, monitoreo y rollback",
+  "category": "rules",
+  "tags": ["deploy", "vercel", "ci-cd", "checklist"],
+  "deps": {
+    "dependencies": [],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/deploy-guide.md", "dest": "rules/deploy-guide.md" }
+  ],
+  "docsUrl": "https://sanghel-playbook.vercel.app/docs/catalog/rules/deploy-guide"
+}
+```
+
+- [ ] **Step 10: Copiar rules/deploy-guide.md como catalog/rules/deploy-guide/files/deploy-guide.md**
+
+```bash
+cp rules/deploy-guide.md catalog/rules/deploy-guide/files/deploy-guide.md
+```
+
+- [ ] **Step 11: Verificar estructura del catálogo**
+
+```bash
+find catalog -type f | sort
+```
+
+Expected output:
+```
+catalog/astro/index.json
+catalog/index.json
+catalog/nextjs/index.json
+catalog/react/index.json
+catalog/rules/deploy-guide/files/deploy-guide.md
+catalog/rules/deploy-guide/manifest.json
+catalog/rules/github-flow/files/github-flow.md
+catalog/rules/github-flow/manifest.json
+catalog/rules/index.json
+```
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add catalog/
+git commit -m "feat: estructura del catálogo con github-flow y deploy-guide"
+```
+
+---
+
+## Task 8: commands/add.ts y commands/create.ts
+
+**Files:**
+- Create: `packages/cli/src/commands/add.ts`
+- Create: `packages/cli/src/commands/create.ts`
+
+- [ ] **Step 1: Crear packages/cli/src/commands/add.ts**
+
+```typescript
+import { execSync } from 'child_process'
+import { fetchCatalogIndex, fetchCategoryIndex, fetchManifest } from '../lib/fetcher.js'
+import { installFiles } from '../lib/installer.js'
+import { detectPackageManager, getInstallCommand } from '../lib/package-manager.js'
+import type { CategoryRef, ManifestItem, InstallStep } from '../types.js'
+
+export async function loadCatalog(): Promise<CategoryRef[]> {
+  const index = await fetchCatalogIndex()
+  return index.categories
+}
+
+export async function loadCategoryItems(categoryId: string): Promise<ManifestItem[]> {
+  const catIndex = await fetchCategoryIndex(categoryId)
+  return Promise.all(catIndex.items.map((id) => fetchManifest(categoryId, id)))
+}
+
+export async function runInstall(
+  manifests: ManifestItem[],
+  cwd: string,
+  onStep: (step: InstallStep) => void
+): Promise<string | null> {
+  const pm = detectPackageManager(cwd) ?? 'npm'
+  let lastDocsUrl: string | null = null
+
+  for (const manifest of manifests) {
+    const fileResults = await installFiles(manifest, cwd)
+    for (const result of fileResults) {
+      onStep({ label: result.path, status: result.skipped ? 'skipped' : 'done' })
+    }
+
+    if (manifest.deps.dependencies.length > 0) {
+      const cmd = getInstallCommand(pm, manifest.deps.dependencies)
+      onStep({ label: cmd, status: 'running' })
+      execSync(cmd, { cwd, stdio: 'pipe' })
+      onStep({ label: cmd, status: 'done' })
+    }
+
+    if (manifest.deps.devDependencies.length > 0) {
+      const cmd = getInstallCommand(pm, manifest.deps.devDependencies, true)
+      onStep({ label: cmd, status: 'running' })
+      execSync(cmd, { cwd, stdio: 'pipe' })
+      onStep({ label: cmd, status: 'done' })
+    }
+
+    lastDocsUrl = manifest.docsUrl
+  }
+
+  return lastDocsUrl
+}
+```
+
+- [ ] **Step 2: Crear packages/cli/src/commands/create.ts**
+
+```typescript
+import { scaffold } from '../lib/scaffolder.js'
+import type { Stack } from '../lib/scaffolder.js'
+
+export type { Stack }
+
+export function createProject(stack: Stack, projectName: string): boolean {
+  return scaffold(stack, projectName)
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/src/commands/
+git commit -m "feat(cli): commands/add y commands/create — lógica de flujo de instalación"
+```
+
+---
+
+## Task 9: UI components — MainMenu y StackMenu
+
+**Files:**
+- Create: `packages/cli/src/ui/MainMenu.tsx`
+- Create: `packages/cli/src/ui/StackMenu.tsx`
+
+- [ ] **Step 1: Crear packages/cli/src/ui/MainMenu.tsx**
+
+```tsx
+import React, { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+
+export type AppMode = 'create' | 'add'
+
+interface Props {
+  onSelect: (mode: AppMode) => void
+}
+
+const OPTIONS: { label: string; value: AppMode }[] = [
+  { label: 'Crear nuevo proyecto', value: 'create' },
+  { label: 'Añadir a proyecto existente', value: 'add' },
+]
+
+export function MainMenu({ onSelect }: Props) {
+  const [cursor, setCursor] = useState(0)
+
+  useInput((_, key) => {
+    if (key.upArrow) setCursor((c) => Math.max(0, c - 1))
+    if (key.downArrow) setCursor((c) => Math.min(OPTIONS.length - 1, c + 1))
+    if (key.return) onSelect(OPTIONS[cursor].value)
+  })
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        sanghel-playbook
+      </Text>
+      <Text> </Text>
+      <Text dimColor>¿Qué quieres hacer?</Text>
+      <Text> </Text>
+      {OPTIONS.map((opt, i) => (
+        <Text key={opt.value} color={i === cursor ? 'green' : undefined}>
+          {i === cursor ? '▶ ' : '  '}
+          {opt.label}
+        </Text>
+      ))}
+      <Text> </Text>
+      <Text dimColor>↑↓ navegar  enter confirmar</Text>
+    </Box>
+  )
+}
+```
+
+- [ ] **Step 2: Crear packages/cli/src/ui/StackMenu.tsx**
+
+```tsx
+import React, { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import type { Stack } from '../commands/create.js'
+
+interface Props {
+  onSelect: (stack: Stack) => void
+  onBack: () => void
+}
+
+const OPTIONS: { label: string; value: Stack }[] = [
+  { label: 'React + Vite', value: 'react-vite' },
+  { label: 'Next.js (create-next-app)', value: 'nextjs' },
+  { label: 'Astro', value: 'astro' },
+]
+
+export function StackMenu({ onSelect, onBack }: Props) {
+  const [cursor, setCursor] = useState(0)
+
+  useInput((_, key) => {
+    if (key.upArrow) setCursor((c) => Math.max(0, c - 1))
+    if (key.downArrow) setCursor((c) => Math.min(OPTIONS.length - 1, c + 1))
+    if (key.return) onSelect(OPTIONS[cursor].value)
+    if (key.escape) onBack()
+  })
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        Nuevo proyecto — elige el stack base
+      </Text>
+      <Text> </Text>
+      {OPTIONS.map((opt, i) => (
+        <Text key={opt.value} color={i === cursor ? 'green' : undefined}>
+          {i === cursor ? '▶ ' : '  '}
+          {opt.label}
+        </Text>
+      ))}
+      <Text> </Text>
+      <Text dimColor>↑↓ navegar  enter confirmar  esc volver</Text>
+    </Box>
+  )
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/src/ui/MainMenu.tsx packages/cli/src/ui/StackMenu.tsx
+git commit -m "feat(cli): ui/MainMenu y ui/StackMenu"
+```
+
+---
+
+## Task 10: UI components — CategoryMenu e ItemSelect
+
+**Files:**
+- Create: `packages/cli/src/ui/CategoryMenu.tsx`
+- Create: `packages/cli/src/ui/ItemSelect.tsx`
+
+- [ ] **Step 1: Crear packages/cli/src/ui/CategoryMenu.tsx**
+
+```tsx
+import React, { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import type { CategoryRef } from '../types.js'
+
+interface Props {
+  categories: CategoryRef[]
+  onSelect: (category: CategoryRef) => void
+  onBack: () => void
+}
+
+export function CategoryMenu({ categories, onSelect, onBack }: Props) {
+  const [cursor, setCursor] = useState(0)
+
+  useInput((_, key) => {
+    if (key.upArrow) setCursor((c) => Math.max(0, c - 1))
+    if (key.downArrow) setCursor((c) => Math.min(categories.length - 1, c + 1))
+    if (key.return) onSelect(categories[cursor])
+    if (key.escape) onBack()
+  })
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        Añadir a proyecto — elige categoría
+      </Text>
+      <Text> </Text>
+      {categories.map((cat, i) => (
+        <Text key={cat.id} color={i === cursor ? 'green' : undefined}>
+          {i === cursor ? '▶ ' : '  '}
+          {cat.label}
+        </Text>
+      ))}
+      <Text> </Text>
+      <Text dimColor>↑↓ navegar  enter confirmar  esc volver</Text>
+    </Box>
+  )
+}
+```
+
+- [ ] **Step 2: Crear packages/cli/src/ui/ItemSelect.tsx**
+
+```tsx
+import React, { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import type { ManifestItem } from '../types.js'
+
+interface Props {
+  items: ManifestItem[]
+  categoryLabel: string
+  onInstall: (selected: ManifestItem[]) => void
+  onBack: () => void
+}
+
+export function ItemSelect({ items, categoryLabel, onInstall, onBack }: Props) {
+  const [cursor, setCursor] = useState(0)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+
+  useInput((input, key) => {
+    if (key.upArrow) setCursor((c) => Math.max(0, c - 1))
+    if (key.downArrow) setCursor((c) => Math.min(items.length - 1, c + 1))
+    if (input === ' ') {
+      setSelected((s) => {
+        const next = new Set(s)
+        const id = items[cursor].id
+        if (next.has(id)) next.delete(id)
+        else next.add(id)
+        return next
+      })
+    }
+    if (key.return) {
+      const toInstall = items.filter((item) => selected.has(item.id))
+      if (toInstall.length > 0) onInstall(toInstall)
+    }
+    if (key.escape) onBack()
+  })
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        {categoryLabel} — selecciona items
+      </Text>
+      <Text> </Text>
+      {items.map((item, i) => (
+        <Box key={item.id} flexDirection="column">
+          <Text color={i === cursor ? 'green' : undefined}>
+            {i === cursor ? '▶ ' : '  '}
+            {selected.has(item.id) ? '[✓] ' : '[ ] '}
+            <Text bold={i === cursor}>{item.name}</Text>
+          </Text>
+          {i === cursor && (
+            <Text dimColor>     {item.description}</Text>
+          )}
+        </Box>
+      ))}
+      <Text> </Text>
+      <Text dimColor>↑↓ navegar  espacio seleccionar  enter instalar  esc volver</Text>
+      {selected.size > 0 && (
+        <Text color="yellow">{selected.size} item(s) seleccionado(s)</Text>
+      )}
+    </Box>
+  )
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/cli/src/ui/CategoryMenu.tsx packages/cli/src/ui/ItemSelect.tsx
+git commit -m "feat(cli): ui/CategoryMenu y ui/ItemSelect con multi-select"
+```
+
+---
+
+## Task 11: UI component — InstallProgress
+
+**Files:**
+- Create: `packages/cli/src/ui/InstallProgress.tsx`
+
+- [ ] **Step 1: Crear packages/cli/src/ui/InstallProgress.tsx**
+
+```tsx
+import React from 'react'
+import { Box, Text } from 'ink'
+import Spinner from 'ink-spinner'
+import type { InstallStep } from '../types.js'
+
+interface Props {
+  steps: InstallStep[]
+  done: boolean
+  docsUrl?: string | null
+}
+
+const ICON: Record<InstallStep['status'], string> = {
+  pending: '○',
+  running: '…',
+  done: '✓',
+  skipped: '⊘',
+  error: '✗',
+}
+
+const COLOR: Record<InstallStep['status'], string | undefined> = {
+  pending: 'gray',
+  running: 'yellow',
+  done: 'green',
+  skipped: 'gray',
+  error: 'red',
+}
+
+export function InstallProgress({ steps, done, docsUrl }: Props) {
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        {done ? 'Listo.' : 'Instalando...'}
+      </Text>
+      <Text> </Text>
+      {steps.map((step, i) => (
+        <Box key={i}>
+          {step.status === 'running' ? (
+            <Text color="yellow">
+              <Spinner type="dots" /> {step.label}
+            </Text>
+          ) : (
+            <Text color={COLOR[step.status]}>
+              {ICON[step.status]} {step.label}
+            </Text>
+          )}
+        </Box>
+      ))}
+      {done && docsUrl && (
+        <>
+          <Text> </Text>
+          <Text color="cyan">Docs: {docsUrl}</Text>
+        </>
+      )}
+    </Box>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/cli/src/ui/InstallProgress.tsx
+git commit -m "feat(cli): ui/InstallProgress con spinner y estado por paso"
+```
+
+---
+
+## Task 12: index.tsx — App state machine + entry point
+
+**Files:**
+- Create: `packages/cli/src/index.tsx`
+
+- [ ] **Step 1: Crear packages/cli/src/index.tsx**
+
+```tsx
+import React, { useState, useEffect, useCallback, useRef } from 'react'
+import { render, Box, Text, useApp } from 'ink'
+import { MainMenu } from './ui/MainMenu.js'
+import { StackMenu } from './ui/StackMenu.js'
+import { CategoryMenu } from './ui/CategoryMenu.js'
+import { ItemSelect } from './ui/ItemSelect.js'
+import { InstallProgress } from './ui/InstallProgress.js'
+import { loadCatalog, loadCategoryItems, runInstall } from './commands/add.js'
+import { createProject } from './commands/create.js'
+import type { CategoryRef, ManifestItem, InstallStep } from './types.js'
+import type { Stack } from './commands/create.js'
+
+type Screen =
+  | { id: 'main-menu' }
+  | { id: 'stack-menu' }
+  | { id: 'loading'; message: string }
+  | { id: 'category-menu'; categories: CategoryRef[] }
+  | { id: 'item-select'; category: CategoryRef; items: ManifestItem[] }
+  | { id: 'install-progress'; steps: InstallStep[]; done: boolean; docsUrl: string | null }
+  | { id: 'error'; message: string }
+
+function App() {
+  const { exit } = useApp()
+  const [screen, setScreen] = useState<Screen>({ id: 'main-menu' })
+  // Preserve categories so ItemSelect's onBack can restore them without re-fetching
+  const categoriesRef = useRef<CategoryRef[]>([])
+
+  const handleMainMenuSelect = useCallback(
+    (mode: 'create' | 'add') => {
+      if (mode === 'create') {
+        setScreen({ id: 'stack-menu' })
+      } else {
+        setScreen({ id: 'loading', message: 'Cargando catálogo...' })
+      }
+    },
+    []
+  )
+
+  // spawnSync with stdio:'inherit' conflicts with Ink's TTY control.
+  // Exit Ink first, run the scaffolder in the raw terminal, then let the user
+  // re-run `npx sanghel-playbook` inside the new project to add patterns.
+  const handleStackSelect = useCallback((stack: Stack) => {
+    exit()
+    const name = `my-${stack}-app`
+    const ok = createProject(stack, name)
+    if (!ok) {
+      console.error('\n✗ Error al crear el proyecto.')
+      process.exit(1)
+    } else {
+      console.log(`\n✓ Proyecto creado. Entra al directorio y corre npx sanghel-playbook para añadir patrones.`)
+    }
+  }, [exit])
+
+  const handleCategorySelect = useCallback(async (category: CategoryRef) => {
+    setScreen({ id: 'loading', message: `Cargando items de ${category.label}...` })
+    try {
+      const items = await loadCategoryItems(category.id)
+      if (items.length === 0) {
+        setScreen({ id: 'error', message: `No hay items disponibles en ${category.label} todavía.` })
+      } else {
+        setScreen({ id: 'item-select', category, items })
+      }
+    } catch (err) {
+      setScreen({ id: 'error', message: `Error al cargar items: ${String(err)}` })
+    }
+  }, [])
+
+  const handleInstall = useCallback(async (manifests: ManifestItem[]) => {
+    const steps: InstallStep[] = []
+    setScreen({ id: 'install-progress', steps: [], done: false, docsUrl: null })
+
+    try {
+      const docsUrl = await runInstall(manifests, process.cwd(), (step) => {
+        steps.push(step)
+        setScreen({ id: 'install-progress', steps: [...steps], done: false, docsUrl: null })
+      })
+      setScreen({ id: 'install-progress', steps: [...steps], done: true, docsUrl })
+    } catch (err) {
+      steps.push({ label: `Error: ${String(err)}`, status: 'error' })
+      setScreen({ id: 'install-progress', steps: [...steps], done: true, docsUrl: null })
+    }
+  }, [])
+
+  // Load catalog when entering loading screen for 'add' flow
+  useEffect(() => {
+    if (screen.id !== 'loading') return
+    if (screen.message !== 'Cargando catálogo...') return
+
+    loadCatalog()
+      .then((categories) => {
+        categoriesRef.current = categories
+        setScreen({ id: 'category-menu', categories })
+      })
+      .catch((err) => {
+        setScreen({ id: 'error', message: `Error al cargar catálogo: ${String(err)}` })
+      })
+  }, [screen])
+
+  if (screen.id === 'main-menu') {
+    return <MainMenu onSelect={handleMainMenuSelect} />
+  }
+
+  if (screen.id === 'stack-menu') {
+    return (
+      <StackMenu
+        onSelect={handleStackSelect}
+        onBack={() => setScreen({ id: 'main-menu' })}
+      />
+    )
+  }
+
+  if (screen.id === 'loading') {
+    return (
+      <Box padding={1}>
+        <Text color="cyan">{screen.message}</Text>
+      </Box>
+    )
+  }
+
+  if (screen.id === 'category-menu') {
+    return (
+      <CategoryMenu
+        categories={screen.categories}
+        onSelect={handleCategorySelect}
+        onBack={() => setScreen({ id: 'main-menu' })}
+      />
+    )
+  }
+
+  if (screen.id === 'item-select') {
+    return (
+      <ItemSelect
+        items={screen.items}
+        categoryLabel={screen.category.label}
+        onInstall={handleInstall}
+        onBack={() => setScreen({ id: 'category-menu', categories: categoriesRef.current })}
+      />
+    )
+  }
+
+  if (screen.id === 'install-progress') {
+    return (
+      <InstallProgress
+        steps={screen.steps}
+        done={screen.done}
+        docsUrl={screen.docsUrl}
+      />
+    )
+  }
+
+  if (screen.id === 'error') {
+    return (
+      <Box padding={1}>
+        <Text color="red">✗ {screen.message}</Text>
+      </Box>
+    )
+  }
+
+  return null
+}
+
+render(<App />)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/cli/src/index.tsx
+git commit -m "feat(cli): index.tsx — App state machine + entry point Ink"
+```
+
+---
+
+## Task 13: Build y verificación end-to-end
+
+**Files:**
+- No nuevos archivos — verificación del build y flujo completo
+
+- [ ] **Step 1: Correr todos los tests**
+
+```bash
+cd packages/cli && pnpm test
+```
+
+Expected: PASS — todos los tests de fetcher, package-manager, installer, scaffolder
+
+- [ ] **Step 2: Compilar el CLI**
+
+```bash
+cd packages/cli && pnpm build
+```
+
+Expected: `dist/index.js` creado sin errores de TypeScript.
+
+- [ ] **Step 3: Verificar que el shebang está en dist/index.js**
+
+```bash
+head -1 packages/cli/dist/index.js
+```
+
+Expected: `#!/usr/bin/env node`
+
+- [ ] **Step 4: Test manual — TUI arranca**
+
+Desde el directorio raíz del proyecto o cualquier otro directorio:
+
+```bash
+node packages/cli/dist/index.js
+```
+
+Expected: aparece el menú principal con las opciones "Crear nuevo proyecto" y "Añadir a proyecto existente". Las flechas navegan. `q` o `ctrl+c` sale.
+
+- [ ] **Step 5: Test manual — flujo añadir (rules)**
+
+Desde un directorio temporal:
+
+```bash
+mkdir /tmp/test-playbook && cd /tmp/test-playbook && node <ruta-absoluta>/packages/cli/dist/index.js
+```
+
+1. Seleccionar "Añadir a proyecto existente"
+2. Seleccionar "Rules & Guides"
+3. Marcar "GitHub Flow" con espacio
+4. Presionar enter
+
+Expected: el archivo `rules/github-flow.md` aparece en `/tmp/test-playbook/rules/`.
+
+- [ ] **Step 6: Commit final de build**
+
+```bash
+cd <raíz del repo>
+git add packages/cli/dist/
+# Agregar dist/ al .gitignore si no se quiere commitear
+echo "packages/cli/dist/" >> .gitignore
+git add .gitignore
+git commit -m "chore: ignorar dist/ del CLI en git"
+```
+
+---
+
+## Task 14: Site docs — actualizar getting-started.mdx
+
+**Files:**
+- Modify: `src/content/docs/getting-started.mdx`
+
+- [ ] **Step 1: Actualizar src/content/docs/getting-started.mdx**
+
+Reemplazar el contenido actual con esta versión actualizada que explica el CLI:
+
+```mdx
+---
+title: Getting Started
+description: Bienvenido a sanghel-playbook — patrones, decisiones de componentes y lecciones de software en producción, instalables desde la terminal.
+order: 1
+---
+
+# Getting Started
+
+Bienvenido a **Sanghel Playbook** — un catálogo vivo de patrones, configuraciones y guías que uso en proyectos de producción.
+
+Puedes consumirlo de dos formas:
+
+---
+
+## CLI/TUI (recomendado)
+
+Instala patrones directamente en tu proyecto desde la terminal, sin necesidad de copiar código manualmente.
+
+```bash
+npx sanghel-playbook
+```
+
+Al ejecutarlo, aparece una TUI interactiva con dos modos:
+
+- **Crear nuevo proyecto** — scaffoldea React + Vite, Next.js o Astro con las herramientas oficiales, y luego ofrece aplicar patrones del catálogo encima.
+- **Añadir a proyecto existente** — navega el catálogo por categoría, selecciona los items que quieres (con espacio), y los instala en tu proyecto actual.
+
+El CLI detecta automáticamente tu package manager (`pnpm`, `yarn` o `npm`) e instala las dependencias necesarias.
+
+### ¿Qué instala?
+
+Cada item del catálogo puede instalar:
+- Archivos de código (hooks, componentes, schemas)
+- Guías y reglas en markdown
+- Dependencias npm requeridas
+
+---
+
+## Documentación navegable (este site)
+
+Explora los patrones con contexto completo: por qué se usan, cuándo aplicarlos, y ejemplos de código. Usa el sidebar para navegar por categoría.
+
+---
+
+## Catálogo actual
+
+El catálogo crece con cada nuevo patrón documentado. Actualmente incluye:
+
+- **React** — patrones de componentes y formularios
+- **Next.js** — server actions, middleware, API routes, sessions
+- **Astro** — islands, routing, content collections
+- **Rules & Guides** — GitHub Flow, Deploy Guide (Vercel)
+
+---
+
+## Contribuir al catálogo
+
+Para añadir un nuevo item:
+
+1. Crear `catalog/{categoria}/{id}/manifest.json` con la metadata
+2. Añadir los archivos fuente en `catalog/{categoria}/{id}/files/`
+3. Crear la doc en `src/content/docs/catalog/{categoria}/{id}.mdx`
+4. Abrir un PR — catálogo y docs se actualizan en el mismo commit
+```
+
+- [ ] **Step 2: Verificar que el site compila**
+
+```bash
+pnpm build
+```
+
+Expected: build de Next.js sin errores.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/content/docs/getting-started.mdx
+git commit -m "docs: actualizar getting-started con instrucciones del CLI"
+```
+
+---
+
+## Verificación final
+
+```bash
+# Todos los tests pasan
+cd packages/cli && pnpm test
+
+# Build del CLI
+pnpm build
+
+# Build del site
+cd ../.. && pnpm build
+
+# Test end-to-end manual
+mkdir /tmp/final-test && cd /tmp/final-test
+node <ruta-a-repo>/packages/cli/dist/index.js
+# → Flujo completo: instalar github-flow desde Rules & Guides
+# → Verificar que /tmp/final-test/rules/github-flow.md existe
+```

--- a/docs/superpowers/specs/2026-05-05-cli-tui-installer-design.md
+++ b/docs/superpowers/specs/2026-05-05-cli-tui-installer-design.md
@@ -1,0 +1,231 @@
+# Design: sanghel-playbook CLI/TUI Installer
+
+## Context
+
+`sanghel-playbook` es actualmente un site de documentación Next.js con patrones de React, Next.js y Astro. El objetivo es transformarlo en algo de mayor alcance: un **CLI/TUI público** que cualquier desarrollador pueda usar para instalar patrones, configuraciones y reglas en sus proyectos — o para arrancar proyectos nuevos desde cero con esas convenciones ya aplicadas. El repo existente se convierte en la fuente de verdad del catálogo Y en el site de documentación del CLI.
+
+---
+
+## Arquitectura: Monorepo ligero
+
+```
+sanghel-playbook/
+├── packages/
+│   └── cli/                        # Paquete npm publicable
+│       ├── src/
+│       │   ├── index.tsx           # Entry point (npx sanghel-playbook)
+│       │   ├── ui/                 # Componentes Ink (pantallas TUI)
+│       │   │   ├── MainMenu.tsx    # ¿Crear proyecto / Añadir a existente?
+│       │   │   ├── CategoryMenu.tsx
+│       │   │   ├── ItemSelect.tsx  # Multi-select con espacio
+│       │   │   └── InstallProgress.tsx
+│       │   ├── commands/
+│       │   │   ├── create.ts       # Modo crear nuevo proyecto
+│       │   │   └── add.ts          # Modo añadir a proyecto existente
+│       │   └── lib/
+│       │       ├── fetcher.ts      # Fetch a GitHub raw
+│       │       ├── installer.ts    # Copy de archivos al cwd del usuario
+│       │       ├── package-manager.ts  # Detecta pnpm/yarn/npm
+│       │       └── scaffolder.ts   # Corre create-next-app, create vite, etc.
+│       ├── package.json            # name: "sanghel-playbook", bin entry
+│       └── tsconfig.json
+│
+├── catalog/                        # Contenido instalable
+│   ├── index.json                  # Lista de categorías
+│   ├── react/
+│   │   ├── index.json              # Items disponibles en React
+│   │   ├── zod-form/
+│   │   │   ├── manifest.json
+│   │   │   └── files/
+│   │   └── controller-hook/
+│   │       ├── manifest.json
+│   │       └── files/
+│   ├── nextjs/
+│   ├── astro/
+│   └── rules/
+│       ├── github-flow/
+│       └── deploy-guide/
+│
+├── src/                            # Site de documentación (sin cambios estructurales)
+│   └── content/docs/
+│       ├── getting-started.mdx     # Actualizado: explica el CLI
+│       ├── catalog/                # Nueva sección: uno por item instalable
+│       ├── react/
+│       ├── nextjs/
+│       └── astro/
+│
+└── package.json                    # workspaces: ["packages/*"]
+```
+
+---
+
+## Catálogo: Formato de datos
+
+### `catalog/index.json`
+```json
+{
+  "categories": [
+    { "id": "react", "label": "React", "indexUrl": "catalog/react/index.json" },
+    { "id": "nextjs", "label": "Next.js", "indexUrl": "catalog/nextjs/index.json" },
+    { "id": "astro", "label": "Astro", "indexUrl": "catalog/astro/index.json" },
+    { "id": "rules", "label": "Rules & Guides", "indexUrl": "catalog/rules/index.json" }
+  ]
+}
+```
+
+### `catalog/react/index.json`
+```json
+{
+  "category": "react",
+  "label": "React",
+  "items": ["zod-form", "controller-hook", "compound-component"]
+}
+```
+
+### `catalog/react/zod-form/manifest.json`
+```json
+{
+  "id": "zod-form",
+  "name": "Zod Form Pattern",
+  "description": "Schema de validación con Zod + React Hook Form con manejo de errores tipado",
+  "category": "react",
+  "tags": ["forms", "validation", "zod"],
+  "deps": {
+    "dependencies": ["zod", "react-hook-form"],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/useZodForm.ts", "dest": "src/hooks/useZodForm.ts" },
+    { "src": "files/FormField.tsx", "dest": "src/components/FormField.tsx" }
+  ],
+  "docsUrl": "https://sanghel-playbook.vercel.app/docs/catalog/react/zod-form"
+}
+```
+
+---
+
+## TUI: Flujo de navegación
+
+```
+npx sanghel-playbook
+        │
+        ▼
+┌─────────────────────────────┐
+│ ¿Qué quieres hacer?         │
+│ ▶ Crear nuevo proyecto      │
+│   Añadir a proyecto exist.  │
+└─────────────────────────────┘
+        │                │
+        │ Crear          │ Añadir
+        ▼                ▼
+┌──────────────┐   ┌──────────────────┐
+│ Elige stack: │   │ Elige categoría: │
+│ ▶ React+Vite │   │ ▶ React          │
+│   Next.js    │   │   Next.js        │
+│   Astro      │   │   Astro          │
+└──────────────┘   │   Rules & Guides │
+        │          └──────────────────┘
+        │ (corre                │
+        │  scaffolder           │ (entra a categoría)
+        │  oficial)             ▼
+        │          ┌──────────────────────────┐
+        │          │ Multi-select (espacio):  │
+        │          │ [✓] Zod Form Pattern     │
+        │          │ [ ] Controller Hook      │
+        │          │ [ ] Compound Component   │
+        │          │ ← volver  enter→instalar │
+        │          └──────────────────────────┘
+        │                       │
+        └───────────────────────┘
+                    │ (tras scaffolding: ¿aplicar patrones?)
+                    ▼
+        ┌─────────────────────────┐
+        │ Instalando...           │
+        │ ✓ src/hooks/useZodForm  │
+        │ ✓ zod instalado         │
+        │ ✓ react-hook-form       │
+        │                         │
+        │ Docs: playbook.dev/...  │
+        └─────────────────────────┘
+```
+
+---
+
+## CLI Internals
+
+### `lib/fetcher.ts`
+- Fetcha desde `https://raw.githubusercontent.com/sanghelgonzalez/sanghel-playbook/main/`
+- Estrategia lazy: descarga `catalog/index.json` al inicio, luego `catalog/{cat}/index.json` al entrar a categoría, y manifests + files solo al instalar
+- Branch configurable (default `main`) para poder testear desde `develop`
+
+### `lib/installer.ts`
+- Resuelve rutas relativas al `process.cwd()` donde el usuario corrió el comando
+- Crea directorios intermedios con `fs.mkdirSync({ recursive: true })`
+- Si archivo destino existe → pregunta confirmación antes de sobreescribir
+
+### `lib/package-manager.ts`
+- Detecta leyendo el directorio raíz:
+  - `pnpm-lock.yaml` → `pnpm add`
+  - `yarn.lock` → `yarn add`
+  - `package-lock.json` → `npm install`
+  - Sin lockfile → pregunta al usuario
+
+### `lib/scaffolder.ts`
+- Mapeo de stacks a comandos:
+  - React + Vite → `npm create vite@latest`
+  - Next.js → `npx create-next-app@latest`
+  - Astro → `npm create astro@latest`
+- Corre con `spawnSync(..., { stdio: 'inherit' })` para que el usuario interactúe directamente con el scaffolder oficial
+- Después ofrece aplicar patrones del catálogo encima del proyecto recién creado
+
+### Stack TUI
+- **Ink** — React para terminal, componentes reutilizables
+- **`@clack/prompts`** — spinners, confirmaciones, progress
+- **TypeScript** strict
+
+---
+
+## Evolución del site de documentación
+
+- `getting-started.mdx` → actualizado: explica el CLI, cómo instalarlo y usarlo
+- Nueva sección **"Catálogo"** en el sidebar con una página por item instalable
+- El `docsUrl` en cada `manifest.json` apunta a esa página
+- Workflow para añadir un nuevo item:
+  1. `catalog/react/mi-patron/manifest.json` + `files/`
+  2. `src/content/docs/catalog/react/mi-patron.mdx`
+  3. Un solo PR actualiza catálogo + docs
+
+---
+
+## Archivos críticos a crear/modificar
+
+| Archivo | Acción |
+|---|---|
+| `package.json` (raíz) | Añadir `workspaces: ["packages/*"]` |
+| `packages/cli/package.json` | Nuevo — `name: "sanghel-playbook"`, `bin` entry |
+| `packages/cli/src/index.tsx` | Nuevo — entry point Ink |
+| `packages/cli/src/ui/*.tsx` | Nuevos — pantallas TUI |
+| `packages/cli/src/lib/*.ts` | Nuevos — fetcher, installer, pkg-manager, scaffolder |
+| `catalog/index.json` | Nuevo — lista categorías |
+| `catalog/*/index.json` | Nuevos — items por categoría |
+| `catalog/*/manifest.json` | Nuevos — metadata de cada item |
+| `src/content/docs/getting-started.mdx` | Modificar — explica el CLI |
+| `src/content/docs/catalog/**` | Nuevas páginas por item |
+
+---
+
+## Limitaciones conocidas (v1)
+
+- Las rutas `dest` en los manifests asumen estructura `src/hooks/`, `src/components/`. Si el proyecto del usuario usa una estructura diferente, deberá mover los archivos manualmente.
+- No hay soporte offline — requiere conexión para fetchear el catálogo desde GitHub.
+
+---
+
+## Verificación
+
+1. `cd packages/cli && npm run build` — compila sin errores
+2. `node dist/index.js` desde un directorio de prueba — TUI arranca y muestra menú principal
+3. Seleccionar un item → archivos aparecen en el directorio correcto
+4. Deps instaladas con el package manager detectado
+5. Modo crear proyecto → scaffolder oficial se ejecuta correctamente
+6. `npx sanghel-playbook` desde un proyecto limpio — flujo completo end-to-end

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sanghel-playbook",
   "version": "0.1.0",
   "private": true,
+  "workspaces": ["packages/*"],
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "tsup",
+    "prepare": "tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "sanghel-playbook",
+  "version": "0.1.0",
+  "description": "CLI/TUI para instalar patrones y scaffoldear proyectos desde el sanghel-playbook",
+  "type": "module",
+  "bin": {
+    "sanghel-playbook": "./dist/index.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "ink": "^5.2.0",
+    "ink-spinner": "^5.0.0",
+    "react": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18",
+    "tsup": "^8",
+    "typescript": "^5",
+    "vitest": "^3"
+  },
+  "files": ["dist"],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,0 +1,59 @@
+import { execSync } from 'child_process'
+import { fetchCatalogIndex, fetchCategoryIndex, fetchManifest } from '../lib/fetcher.js'
+import { installFiles } from '../lib/installer.js'
+import { detectPackageManager, getInstallCommand } from '../lib/package-manager.js'
+import type { CategoryRef, ManifestItem, InstallStep } from '../types.js'
+
+export async function loadCatalog(): Promise<CategoryRef[]> {
+  const index = await fetchCatalogIndex()
+  return index.categories
+}
+
+export async function loadCategoryItems(categoryId: string): Promise<ManifestItem[]> {
+  const catIndex = await fetchCategoryIndex(categoryId)
+  return Promise.all(catIndex.items.map((id) => fetchManifest(categoryId, id)))
+}
+
+export async function runInstall(
+  manifests: ManifestItem[],
+  cwd: string,
+  onStep: (step: InstallStep) => void
+): Promise<string | null> {
+  const pm = detectPackageManager(cwd) ?? 'npm'
+  let lastDocsUrl: string | null = null
+
+  for (const manifest of manifests) {
+    const fileResults = await installFiles(manifest, cwd)
+    for (const result of fileResults) {
+      onStep({ label: result.path, status: result.error ? 'error' : result.skipped ? 'skipped' : 'done' })
+    }
+
+    if (manifest.deps.dependencies.length > 0) {
+      const cmd = getInstallCommand(pm, manifest.deps.dependencies)
+      onStep({ label: cmd, status: 'running' })
+      try {
+        execSync(cmd, { cwd, stdio: 'pipe' })
+        onStep({ label: cmd, status: 'done' })
+      } catch {
+        onStep({ label: cmd, status: 'error' })
+        throw new Error(`Failed to install dependencies: ${cmd}`)
+      }
+    }
+
+    if (manifest.deps.devDependencies.length > 0) {
+      const cmd = getInstallCommand(pm, manifest.deps.devDependencies, true)
+      onStep({ label: cmd, status: 'running' })
+      try {
+        execSync(cmd, { cwd, stdio: 'pipe' })
+        onStep({ label: cmd, status: 'done' })
+      } catch {
+        onStep({ label: cmd, status: 'error' })
+        throw new Error(`Failed to install devDependencies: ${cmd}`)
+      }
+    }
+
+    lastDocsUrl = manifest.docsUrl
+  }
+
+  return lastDocsUrl
+}

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,0 +1,8 @@
+import { scaffold } from '../lib/scaffolder.js'
+import type { Stack } from '../lib/scaffolder.js'
+
+export type { Stack }
+
+export function createProject(stack: Stack, projectName: string): boolean {
+  return scaffold(stack, projectName)
+}

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -1,0 +1,165 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react'
+import { render, Box, Text, useApp } from 'ink'
+import { MainMenu } from './ui/MainMenu.js'
+import { StackMenu } from './ui/StackMenu.js'
+import { CategoryMenu } from './ui/CategoryMenu.js'
+import { ItemSelect } from './ui/ItemSelect.js'
+import { InstallProgress } from './ui/InstallProgress.js'
+import { loadCatalog, loadCategoryItems, runInstall } from './commands/add.js'
+import { createProject } from './commands/create.js'
+import type { CategoryRef, ManifestItem, InstallStep } from './types.js'
+import type { Stack } from './commands/create.js'
+
+type Screen =
+  | { id: 'main-menu' }
+  | { id: 'stack-menu' }
+  | { id: 'loading'; message: string }
+  | { id: 'category-menu'; categories: CategoryRef[] }
+  | { id: 'item-select'; category: CategoryRef; items: ManifestItem[] }
+  | { id: 'install-progress'; steps: InstallStep[]; done: boolean; docsUrl: string | null }
+  | { id: 'error'; message: string }
+
+function App() {
+  const { exit } = useApp()
+  const [screen, setScreen] = useState<Screen>({ id: 'main-menu' })
+  // Preserve categories so ItemSelect's onBack can restore them without re-fetching
+  const categoriesRef = useRef<CategoryRef[]>([])
+
+  const handleMainMenuSelect = useCallback(
+    (mode: 'create' | 'add') => {
+      if (mode === 'create') {
+        setScreen({ id: 'stack-menu' })
+      } else {
+        setScreen({ id: 'loading', message: 'Cargando catálogo...' })
+      }
+    },
+    []
+  )
+
+  // spawnSync with stdio:'inherit' conflicts with Ink's TTY control.
+  // Exit Ink first, defer createProject to let Ink finish teardown, then scaffold.
+  const handleStackSelect = useCallback((stack: Stack) => {
+    exit()
+    setImmediate(() => {
+      const name = `my-${stack}-app`
+      const ok = createProject(stack, name)
+      if (!ok) {
+        console.error('\n✗ Error al crear el proyecto.')
+        process.exit(1)
+      } else {
+        console.log(`\n✓ Proyecto creado. Entra al directorio y corre npx sanghel-playbook para añadir patrones.`)
+      }
+    })
+  }, [exit])
+
+  const handleCategorySelect = useCallback(async (category: CategoryRef) => {
+    setScreen({ id: 'loading', message: `Cargando items de ${category.label}...` })
+    try {
+      const items = await loadCategoryItems(category.id)
+      if (items.length === 0) {
+        setScreen({ id: 'error', message: `No hay items disponibles en ${category.label} todavía.` })
+      } else {
+        setScreen({ id: 'item-select', category, items })
+      }
+    } catch (err) {
+      setScreen({ id: 'error', message: `Error al cargar items: ${String(err)}` })
+    }
+  }, [])
+
+  const handleInstall = useCallback(async (manifests: ManifestItem[]) => {
+    const steps: InstallStep[] = []
+    setScreen({ id: 'install-progress', steps: [], done: false, docsUrl: null })
+
+    try {
+      const docsUrl = await runInstall(manifests, process.cwd(), (step) => {
+        steps.push(step)
+        setScreen({ id: 'install-progress', steps: [...steps], done: false, docsUrl: null })
+      })
+      setScreen({ id: 'install-progress', steps: [...steps], done: true, docsUrl })
+    } catch (err) {
+      steps.push({ label: `Error: ${String(err)}`, status: 'error' })
+      setScreen({ id: 'install-progress', steps: [...steps], done: true, docsUrl: null })
+    }
+  }, [])
+
+  const shouldLoadCatalog = screen.id === 'loading' && screen.message === 'Cargando catálogo...'
+
+  // Load catalog when entering loading screen for 'add' flow
+  useEffect(() => {
+    if (!shouldLoadCatalog) return
+
+    loadCatalog()
+      .then((categories) => {
+        categoriesRef.current = categories
+        setScreen({ id: 'category-menu', categories })
+      })
+      .catch((err) => {
+        setScreen({ id: 'error', message: `Error al cargar catálogo: ${String(err)}` })
+      })
+  }, [shouldLoadCatalog])
+
+  if (screen.id === 'main-menu') {
+    return <MainMenu onSelect={handleMainMenuSelect} />
+  }
+
+  if (screen.id === 'stack-menu') {
+    return (
+      <StackMenu
+        onSelect={handleStackSelect}
+        onBack={() => setScreen({ id: 'main-menu' })}
+      />
+    )
+  }
+
+  if (screen.id === 'loading') {
+    return (
+      <Box padding={1}>
+        <Text color="cyan">{screen.message}</Text>
+      </Box>
+    )
+  }
+
+  if (screen.id === 'category-menu') {
+    return (
+      <CategoryMenu
+        categories={screen.categories}
+        onSelect={handleCategorySelect}
+        onBack={() => setScreen({ id: 'main-menu' })}
+      />
+    )
+  }
+
+  if (screen.id === 'item-select') {
+    return (
+      <ItemSelect
+        items={screen.items}
+        categoryLabel={screen.category.label}
+        onInstall={handleInstall}
+        onBack={() => setScreen({ id: 'category-menu', categories: categoriesRef.current })}
+      />
+    )
+  }
+
+  if (screen.id === 'install-progress') {
+    return (
+      <InstallProgress
+        steps={screen.steps}
+        done={screen.done}
+        docsUrl={screen.docsUrl}
+      />
+    )
+  }
+
+  if (screen.id === 'error') {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color="red">✗ {screen.message}</Text>
+        <Text dimColor>Ctrl+C para salir</Text>
+      </Box>
+    )
+  }
+
+  return null
+}
+
+render(<App />)

--- a/packages/cli/src/lib/fetcher.test.ts
+++ b/packages/cli/src/lib/fetcher.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchJson, fetchText, fetchCatalogIndex, fetchCategoryIndex, fetchManifest, fetchFile } from './fetcher.js'
+
+const BASE = 'https://raw.githubusercontent.com/Sanghel/sanghel-playbook/main'
+
+global.fetch = vi.fn()
+
+describe('fetchJson', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('fetches and parses JSON from the correct URL', async () => {
+    const mockData = { categories: [] }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockData),
+    } as Response)
+
+    const result = await fetchJson('catalog/index.json')
+
+    expect(fetch).toHaveBeenCalledWith(`${BASE}/catalog/index.json`)
+    expect(result).toEqual(mockData)
+  })
+
+  it('throws when response is not ok', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 404 } as Response)
+
+    await expect(fetchJson('catalog/index.json')).rejects.toThrow(
+      'Failed to fetch catalog/index.json: 404'
+    )
+  })
+})
+
+describe('fetchText', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('fetches text content from the correct URL', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('file content here'),
+    } as unknown as Response)
+
+    const result = await fetchText('catalog/rules/github-flow/files/github-flow.md')
+
+    expect(fetch).toHaveBeenCalledWith(`${BASE}/catalog/rules/github-flow/files/github-flow.md`)
+    expect(result).toBe('file content here')
+  })
+
+  it('throws when response is not ok', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: false, status: 500 } as Response)
+
+    await expect(fetchText('catalog/rules/github-flow/files/github-flow.md')).rejects.toThrow(
+      'Failed to fetch catalog/rules/github-flow/files/github-flow.md: 500'
+    )
+  })
+})
+
+describe('fetchCatalogIndex', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('fetches catalog/index.json', async () => {
+    const mockIndex = { categories: [{ id: 'react', label: 'React', indexUrl: 'catalog/react/index.json' }] }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockIndex),
+    } as Response)
+
+    const result = await fetchCatalogIndex()
+    expect(fetch).toHaveBeenCalledWith(`${BASE}/catalog/index.json`)
+    expect(result.categories).toHaveLength(1)
+  })
+})
+
+describe('fetchCategoryIndex', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('fetches catalog/{categoryId}/index.json', async () => {
+    const mockCatIndex = { category: 'react', label: 'React', items: ['zod-form'] }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockCatIndex),
+    } as Response)
+
+    const result = await fetchCategoryIndex('react')
+    expect(fetch).toHaveBeenCalledWith(`${BASE}/catalog/react/index.json`)
+    expect(result.items).toEqual(['zod-form'])
+  })
+})
+
+describe('fetchManifest', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('fetches catalog/{categoryId}/{itemId}/manifest.json', async () => {
+    const mockManifest = { id: 'zod-form', name: 'Zod Form', description: '', category: 'react', tags: [], deps: { dependencies: [], devDependencies: [] }, files: [], docsUrl: '' }
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockManifest),
+    } as Response)
+
+    const result = await fetchManifest('react', 'zod-form')
+    expect(fetch).toHaveBeenCalledWith(`${BASE}/catalog/react/zod-form/manifest.json`)
+    expect(result.id).toBe('zod-form')
+  })
+})
+
+describe('fetchFile', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('fetches catalog/{categoryId}/{itemId}/files/{filename}', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: true,
+      text: () => Promise.resolve('export const x = 1'),
+    } as unknown as Response)
+
+    const result = await fetchFile('react', 'zod-form', 'useZodForm.ts')
+    expect(fetch).toHaveBeenCalledWith(`${BASE}/catalog/react/zod-form/files/useZodForm.ts`)
+    expect(result).toBe('export const x = 1')
+  })
+})

--- a/packages/cli/src/lib/fetcher.ts
+++ b/packages/cli/src/lib/fetcher.ts
@@ -1,0 +1,41 @@
+import type { CatalogIndex, CategoryIndex, ManifestItem } from '../types.js'
+
+const BASE_URL = 'https://raw.githubusercontent.com/Sanghel/sanghel-playbook/main'
+
+export async function fetchJson<T>(path: string): Promise<T> {
+  let res: Response
+  try {
+    res = await fetch(`${BASE_URL}/${path}`)
+  } catch (cause) {
+    throw new Error(`Network error fetching ${path}`, { cause })
+  }
+  if (!res.ok) throw new Error(`Failed to fetch ${path}: ${res.status}`)
+  return res.json() as Promise<T>
+}
+
+export async function fetchText(path: string): Promise<string> {
+  let res: Response
+  try {
+    res = await fetch(`${BASE_URL}/${path}`)
+  } catch (cause) {
+    throw new Error(`Network error fetching ${path}`, { cause })
+  }
+  if (!res.ok) throw new Error(`Failed to fetch ${path}: ${res.status}`)
+  return res.text()
+}
+
+export async function fetchCatalogIndex(): Promise<CatalogIndex> {
+  return fetchJson<CatalogIndex>('catalog/index.json')
+}
+
+export async function fetchCategoryIndex(categoryId: string): Promise<CategoryIndex> {
+  return fetchJson<CategoryIndex>(`catalog/${categoryId}/index.json`)
+}
+
+export async function fetchManifest(categoryId: string, itemId: string): Promise<ManifestItem> {
+  return fetchJson<ManifestItem>(`catalog/${categoryId}/${itemId}/manifest.json`)
+}
+
+export async function fetchFile(categoryId: string, itemId: string, filename: string): Promise<string> {
+  return fetchText(`catalog/${categoryId}/${itemId}/files/${filename}`)
+}

--- a/packages/cli/src/lib/installer.test.ts
+++ b/packages/cli/src/lib/installer.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { installFiles } from './installer.js'
+import * as fetcher from './fetcher.js'
+import type { ManifestItem } from '../types.js'
+
+vi.mock('./fetcher.js')
+
+const mockManifest: ManifestItem = {
+  id: 'zod-form',
+  name: 'Zod Form Pattern',
+  description: 'Test',
+  category: 'react',
+  tags: [],
+  deps: { dependencies: ['zod'], devDependencies: [] },
+  files: [
+    { src: 'files/useZodForm.ts', dest: 'src/hooks/useZodForm.ts' },
+  ],
+  docsUrl: 'https://example.com',
+}
+
+describe('installFiles', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'installer-test-'))
+    vi.mocked(fetcher.fetchFile).mockResolvedValue('export const useZodForm = () => ({})')
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true })
+    vi.resetAllMocks()
+  })
+
+  it('escribe el archivo en el destino correcto', async () => {
+    const results = await installFiles(mockManifest, tmpDir)
+
+    expect(results).toHaveLength(1)
+    expect(results[0].path).toBe('src/hooks/useZodForm.ts')
+    expect(results[0].skipped).toBe(false)
+    expect(existsSync(join(tmpDir, 'src/hooks/useZodForm.ts'))).toBe(true)
+    expect(readFileSync(join(tmpDir, 'src/hooks/useZodForm.ts'), 'utf-8')).toBe('export const useZodForm = () => ({})')
+  })
+
+  it('crea directorios intermedios si no existen', async () => {
+    await installFiles(mockManifest, tmpDir)
+    expect(existsSync(join(tmpDir, 'src/hooks'))).toBe(true)
+  })
+
+  it('llama a fetchFile con los parámetros correctos', async () => {
+    await installFiles(mockManifest, tmpDir)
+    expect(fetcher.fetchFile).toHaveBeenCalledWith('react', 'zod-form', 'useZodForm.ts')
+  })
+
+  it('marca como skipped si el archivo ya existe', async () => {
+    await installFiles(mockManifest, tmpDir)
+    const results = await installFiles(mockManifest, tmpDir)
+
+    expect(results[0].skipped).toBe(true)
+    expect(fetcher.fetchFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('instala múltiples archivos del mismo manifest', async () => {
+    const manifest: ManifestItem = {
+      ...mockManifest,
+      files: [
+        { src: 'files/useZodForm.ts', dest: 'src/hooks/useZodForm.ts' },
+        { src: 'files/FormField.tsx', dest: 'src/components/FormField.tsx' },
+      ],
+    }
+    vi.mocked(fetcher.fetchFile).mockResolvedValue('// content')
+
+    const results = await installFiles(manifest, tmpDir)
+    expect(results).toHaveLength(2)
+    expect(results.every(r => !r.skipped)).toBe(true)
+  })
+
+  it('registra error en el resultado si fetchFile falla', async () => {
+    vi.mocked(fetcher.fetchFile).mockRejectedValueOnce(new Error('Network error fetching file'))
+
+    const results = await installFiles(mockManifest, tmpDir)
+    expect(results[0].skipped).toBe(false)
+    expect(results[0].error).toBe('Network error fetching file')
+  })
+})

--- a/packages/cli/src/lib/installer.ts
+++ b/packages/cli/src/lib/installer.ts
@@ -1,0 +1,32 @@
+import { writeFileSync, mkdirSync, existsSync } from 'fs'
+import { join, dirname, basename } from 'path'
+import { fetchFile } from './fetcher.js'
+import type { ManifestItem, InstallResult } from '../types.js'
+
+export async function installFiles(
+  manifest: ManifestItem,
+  cwd: string = process.cwd()
+): Promise<InstallResult[]> {
+  const results: InstallResult[] = []
+
+  for (const file of manifest.files) {
+    const destPath = join(cwd, file.dest)
+
+    if (existsSync(destPath)) {
+      results.push({ path: file.dest, skipped: true })
+      continue
+    }
+
+    try {
+      const content = await fetchFile(manifest.category, manifest.id, basename(file.src))
+      mkdirSync(dirname(destPath), { recursive: true })
+      writeFileSync(destPath, content, 'utf-8')
+      results.push({ path: file.dest, skipped: false })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      results.push({ path: file.dest, skipped: false, error: message })
+    }
+  }
+
+  return results
+}

--- a/packages/cli/src/lib/package-manager.test.ts
+++ b/packages/cli/src/lib/package-manager.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { existsSync } from 'fs'
+import { detectPackageManager, getInstallCommand } from './package-manager.js'
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+}))
+
+describe('detectPackageManager', () => {
+  afterEach(() => vi.resetAllMocks())
+
+  it('detecta pnpm por pnpm-lock.yaml', () => {
+    vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith('pnpm-lock.yaml'))
+    expect(detectPackageManager('/fake/dir')).toBe('pnpm')
+  })
+
+  it('detecta yarn por yarn.lock', () => {
+    vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith('yarn.lock'))
+    expect(detectPackageManager('/fake/dir')).toBe('yarn')
+  })
+
+  it('detecta npm por package-lock.json', () => {
+    vi.mocked(existsSync).mockImplementation((p) => String(p).endsWith('package-lock.json'))
+    expect(detectPackageManager('/fake/dir')).toBe('npm')
+  })
+
+  it('devuelve null si no hay lockfile', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    expect(detectPackageManager('/fake/dir')).toBeNull()
+  })
+
+  it('prioriza pnpm sobre los demás', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    expect(detectPackageManager('/fake/dir')).toBe('pnpm')
+  })
+})
+
+describe('getInstallCommand', () => {
+  it('pnpm: pnpm add deps', () => {
+    expect(getInstallCommand('pnpm', ['zod', 'react-hook-form'])).toBe('pnpm add zod react-hook-form')
+  })
+
+  it('yarn: yarn add deps', () => {
+    expect(getInstallCommand('yarn', ['zod'])).toBe('yarn add zod')
+  })
+
+  it('npm: npm install deps', () => {
+    expect(getInstallCommand('npm', ['zod'])).toBe('npm install zod')
+  })
+
+  it('pnpm devDeps: pnpm add -D', () => {
+    expect(getInstallCommand('pnpm', ['vitest'], true)).toBe('pnpm add -D vitest')
+  })
+
+  it('yarn devDeps: yarn add -D', () => {
+    expect(getInstallCommand('yarn', ['vitest'], true)).toBe('yarn add -D vitest')
+  })
+
+  it('npm devDeps: npm install --save-dev', () => {
+    expect(getInstallCommand('npm', ['vitest'], true)).toBe('npm install --save-dev vitest')
+  })
+
+  it('lanza error si deps está vacío', () => {
+    expect(() => getInstallCommand('pnpm', [])).toThrow('deps must not be empty')
+  })
+})

--- a/packages/cli/src/lib/package-manager.ts
+++ b/packages/cli/src/lib/package-manager.ts
@@ -1,0 +1,21 @@
+import { existsSync } from 'fs'
+import { join } from 'path'
+
+export type PackageManager = 'pnpm' | 'yarn' | 'npm'
+
+export function detectPackageManager(cwd: string = process.cwd()): PackageManager | null {
+  if (existsSync(join(cwd, 'pnpm-lock.yaml'))) return 'pnpm'
+  if (existsSync(join(cwd, 'yarn.lock'))) return 'yarn'
+  if (existsSync(join(cwd, 'package-lock.json'))) return 'npm'
+  return null
+}
+
+export function getInstallCommand(pm: PackageManager, deps: string[], dev = false): string {
+  if (deps.length === 0) throw new Error('deps must not be empty')
+  const depStr = deps.join(' ')
+  if (pm === 'pnpm') return dev ? `pnpm add -D ${depStr}` : `pnpm add ${depStr}`
+  if (pm === 'yarn') return dev ? `yarn add -D ${depStr}` : `yarn add ${depStr}`
+  if (pm === 'npm') return dev ? `npm install --save-dev ${depStr}` : `npm install ${depStr}`
+  const _exhaustive: never = pm
+  throw new Error(`Unhandled package manager: ${_exhaustive}`)
+}

--- a/packages/cli/src/lib/scaffolder.test.ts
+++ b/packages/cli/src/lib/scaffolder.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import { spawnSync } from 'child_process'
+import { scaffold } from './scaffolder.js'
+
+vi.mock('child_process', () => ({
+  spawnSync: vi.fn(() => ({ status: 0 })),
+}))
+
+describe('scaffold', () => {
+  it('react-vite: corre npm create vite@latest', () => {
+    scaffold('react-vite', 'my-app')
+    expect(spawnSync).toHaveBeenCalledWith(
+      'npm',
+      ['create', 'vite@latest', 'my-app'],
+      { stdio: 'inherit', shell: true }
+    )
+  })
+
+  it('nextjs: corre npx create-next-app@latest', () => {
+    scaffold('nextjs', 'my-app')
+    expect(spawnSync).toHaveBeenCalledWith(
+      'npx',
+      ['create-next-app@latest', 'my-app'],
+      { stdio: 'inherit', shell: true }
+    )
+  })
+
+  it('astro: corre npm create astro@latest', () => {
+    scaffold('astro', 'my-app')
+    expect(spawnSync).toHaveBeenCalledWith(
+      'npm',
+      ['create', 'astro@latest', 'my-app'],
+      { stdio: 'inherit', shell: true }
+    )
+  })
+
+  it('retorna true cuando status es 0', () => {
+    expect(scaffold('react-vite', 'my-app')).toBe(true)
+  })
+
+  it('retorna false cuando status es distinto de 0', () => {
+    vi.mocked(spawnSync).mockReturnValueOnce({ status: 1 } as ReturnType<typeof spawnSync>)
+    expect(scaffold('nextjs', 'my-app')).toBe(false)
+  })
+
+  it('lanza error cuando status es null (comando no encontrado)', () => {
+    vi.mocked(spawnSync).mockReturnValueOnce({ status: null, error: new Error('spawn npm ENOENT'), signal: null } as unknown as ReturnType<typeof spawnSync>)
+    expect(() => scaffold('react-vite', 'my-app')).toThrow('spawn npm ENOENT')
+  })
+})

--- a/packages/cli/src/lib/scaffolder.ts
+++ b/packages/cli/src/lib/scaffolder.ts
@@ -1,0 +1,20 @@
+import { spawnSync } from 'child_process'
+
+export type Stack = 'react-vite' | 'nextjs' | 'astro'
+
+type Command = [string, string[]]
+
+const COMMANDS: Record<Stack, Command> = {
+  'react-vite': ['npm', ['create', 'vite@latest']],
+  'nextjs': ['npx', ['create-next-app@latest']],
+  'astro': ['npm', ['create', 'astro@latest']],
+}
+
+export function scaffold(stack: Stack, projectName: string): boolean {
+  const [cmd, args] = COMMANDS[stack]
+  const result = spawnSync(cmd, [...args, projectName], { stdio: 'inherit', shell: true })
+  if (result.status === null) {
+    throw result.error ?? new Error(`Spawning ${cmd} failed (signal: ${result.signal})`)
+  }
+  return result.status === 0
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,0 +1,47 @@
+export interface CatalogIndex {
+  categories: CategoryRef[]
+}
+
+export interface CategoryRef {
+  id: string
+  label: string
+  indexUrl: string
+}
+
+export interface CategoryIndex {
+  category: string
+  label: string
+  items: string[]
+}
+
+export interface DepsMap {
+  dependencies: string[]
+  devDependencies: string[]
+}
+
+export interface ManifestItem {
+  id: string
+  name: string
+  description: string
+  category: string
+  tags: string[]
+  deps: DepsMap
+  files: FileEntry[]
+  docsUrl: string
+}
+
+export interface FileEntry {
+  src: string
+  dest: string
+}
+
+export interface InstallResult {
+  path: string
+  skipped: boolean
+  error?: string
+}
+
+export interface InstallStep {
+  label: string
+  status: 'pending' | 'running' | 'done' | 'skipped' | 'error'
+}

--- a/packages/cli/src/ui/CategoryMenu.tsx
+++ b/packages/cli/src/ui/CategoryMenu.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import type { CategoryRef } from '../types.js'
+
+interface Props {
+  categories: CategoryRef[]
+  onSelect: (category: CategoryRef) => void
+  onBack: () => void
+}
+
+export function CategoryMenu({ categories, onSelect, onBack }: Props) {
+  const [cursor, setCursor] = useState(0)
+
+  useInput((_, key) => {
+    if (categories.length === 0) {
+      if (key.escape) onBack()
+      return
+    }
+    if (key.upArrow) setCursor((c) => Math.max(0, c - 1))
+    if (key.downArrow) setCursor((c) => Math.min(categories.length - 1, c + 1))
+    if (key.return) onSelect(categories[cursor])
+    if (key.escape) onBack()
+  })
+
+  if (categories.length === 0) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text dimColor>No hay categorías disponibles.</Text>
+        <Text dimColor>esc volver</Text>
+      </Box>
+    )
+  }
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        Añadir a proyecto — elige categoría
+      </Text>
+      <Text> </Text>
+      {categories.map((cat, i) => (
+        <Text key={cat.id} color={i === cursor ? 'green' : undefined}>
+          {i === cursor ? '▶ ' : '  '}
+          {cat.label}
+        </Text>
+      ))}
+      <Text> </Text>
+      <Text dimColor>↑↓ navegar  enter confirmar  esc volver</Text>
+    </Box>
+  )
+}

--- a/packages/cli/src/ui/InstallProgress.tsx
+++ b/packages/cli/src/ui/InstallProgress.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { Box, Text } from 'ink'
+import Spinner from 'ink-spinner'
+import type { InstallStep } from '../types.js'
+
+interface Props {
+  steps: InstallStep[]
+  done: boolean
+  docsUrl?: string | null
+}
+
+const ICON: Record<InstallStep['status'], string> = {
+  pending: '○',
+  running: '…',
+  done: '✓',
+  skipped: '⊘',
+  error: '✗',
+}
+
+const COLOR: Record<InstallStep['status'], string | undefined> = {
+  pending: 'gray',
+  running: 'yellow',
+  done: 'green',
+  skipped: 'gray',
+  error: 'red',
+}
+
+export function InstallProgress({ steps, done, docsUrl }: Props) {
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        {done ? 'Listo.' : 'Instalando...'}
+      </Text>
+      <Text> </Text>
+      {steps.map((step, i) => (
+        <Box key={`${i}-${step.label}`}>
+          {step.status === 'running' ? (
+            <Text color="yellow">
+              <Spinner type="dots" /> {step.label}
+            </Text>
+          ) : (
+            <Text color={COLOR[step.status]}>
+              {ICON[step.status]} {step.label}
+            </Text>
+          )}
+        </Box>
+      ))}
+      {done && docsUrl && (
+        <>
+          <Text> </Text>
+          <Text color="cyan">Docs: {docsUrl}</Text>
+        </>
+      )}
+    </Box>
+  )
+}

--- a/packages/cli/src/ui/ItemSelect.tsx
+++ b/packages/cli/src/ui/ItemSelect.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import type { ManifestItem } from '../types.js'
+
+interface Props {
+  items: ManifestItem[]
+  categoryLabel: string
+  onInstall: (selected: ManifestItem[]) => void
+  onBack: () => void
+}
+
+export function ItemSelect({ items, categoryLabel, onInstall, onBack }: Props) {
+  const [cursor, setCursor] = useState(0)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+
+  useInput((input, key) => {
+    if (items.length === 0) {
+      if (key.escape) onBack()
+      return
+    }
+    if (key.upArrow) setCursor((c) => Math.max(0, c - 1))
+    if (key.downArrow) setCursor((c) => Math.min(items.length - 1, c + 1))
+    if (input === ' ') {
+      setSelected((s) => {
+        const next = new Set(s)
+        const id = items[cursor].id
+        if (next.has(id)) next.delete(id)
+        else next.add(id)
+        return next
+      })
+    }
+    if (key.return) {
+      const toInstall = items.filter((item) => selected.has(item.id))
+      if (toInstall.length > 0) onInstall(toInstall)
+    }
+    if (key.escape) onBack()
+  })
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        {categoryLabel} — selecciona items
+      </Text>
+      <Text> </Text>
+      {items.map((item, i) => (
+        <Box key={item.id} flexDirection="column">
+          <Text color={i === cursor ? 'green' : undefined}>
+            {i === cursor ? '▶ ' : '  '}
+            {selected.has(item.id) ? '[✓] ' : '[ ] '}
+            <Text bold={i === cursor}>{item.name}</Text>
+          </Text>
+          {i === cursor && (
+            <Text dimColor>     {item.description}</Text>
+          )}
+        </Box>
+      ))}
+      <Text> </Text>
+      <Text dimColor>↑↓ navegar  espacio seleccionar  enter instalar  esc volver</Text>
+      {selected.size > 0 && (
+        <Text color="yellow">{selected.size} item(s) seleccionado(s)</Text>
+      )}
+    </Box>
+  )
+}

--- a/packages/cli/src/ui/MainMenu.tsx
+++ b/packages/cli/src/ui/MainMenu.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+
+export type AppMode = 'create' | 'add'
+
+interface Props {
+  onSelect: (mode: AppMode) => void
+}
+
+const OPTIONS: { label: string; value: AppMode }[] = [
+  { label: 'Crear nuevo proyecto', value: 'create' },
+  { label: 'Añadir a proyecto existente', value: 'add' },
+]
+
+export function MainMenu({ onSelect }: Props) {
+  const [cursor, setCursor] = useState(0)
+
+  useInput((_, key) => {
+    if (key.upArrow) setCursor((c) => Math.max(0, c - 1))
+    if (key.downArrow) setCursor((c) => Math.min(OPTIONS.length - 1, c + 1))
+    if (key.return) onSelect(OPTIONS[cursor].value)
+  })
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        sanghel-playbook
+      </Text>
+      <Text> </Text>
+      <Text dimColor>¿Qué quieres hacer?</Text>
+      <Text> </Text>
+      {OPTIONS.map((opt, i) => (
+        <Text key={opt.value} color={i === cursor ? 'green' : undefined}>
+          {i === cursor ? '▶ ' : '  '}
+          {opt.label}
+        </Text>
+      ))}
+      <Text> </Text>
+      <Text dimColor>↑↓ navegar  enter confirmar</Text>
+    </Box>
+  )
+}

--- a/packages/cli/src/ui/StackMenu.tsx
+++ b/packages/cli/src/ui/StackMenu.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import type { Stack } from '../commands/create.js'
+
+interface Props {
+  onSelect: (stack: Stack) => void
+  onBack: () => void
+}
+
+const OPTIONS: { label: string; value: Stack }[] = [
+  { label: 'React + Vite', value: 'react-vite' },
+  { label: 'Next.js (create-next-app)', value: 'nextjs' },
+  { label: 'Astro', value: 'astro' },
+]
+
+export function StackMenu({ onSelect, onBack }: Props) {
+  const [cursor, setCursor] = useState(0)
+
+  useInput((_, key) => {
+    if (key.upArrow) setCursor((c) => Math.max(0, c - 1))
+    if (key.downArrow) setCursor((c) => Math.min(OPTIONS.length - 1, c + 1))
+    if (key.return) onSelect(OPTIONS[cursor].value)
+    if (key.escape) onBack()
+  })
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        Nuevo proyecto — elige el stack base
+      </Text>
+      <Text> </Text>
+      {OPTIONS.map((opt, i) => (
+        <Text key={opt.value} color={i === cursor ? 'green' : undefined}>
+          {i === cursor ? '▶ ' : '  '}
+          {opt.label}
+        </Text>
+      ))}
+      <Text> </Text>
+      <Text dimColor>↑↓ navegar  enter confirmar  esc volver</Text>
+    </Box>
+  )
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "jsxImportSource": "react",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.tsx'],
+  format: ['esm'],
+  target: 'node18',
+  outDir: 'dist',
+  banner: {
+    js: '#!/usr/bin/env node',
+  },
+  jsx: 'transform',
+  jsxImportSource: 'react',
+  clean: true,
+  sourcemap: false,
+})

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,36 @@ importers:
         specifier: ^5
         version: 5.9.3
 
+  packages/cli:
+    dependencies:
+      ink:
+        specifier: ^5.2.0
+        version: 5.2.1(@types/react@18.3.28)(react@18.3.1)
+      ink-spinner:
+        specifier: ^5.0.0
+        version: 5.0.0(ink@5.2.1(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+    devDependencies:
+      '@types/react':
+        specifier: ^18
+        version: 18.3.28
+      tsup:
+        specifier: ^8
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5
+        version: 5.9.3
+      vitest:
+        specifier: ^3
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+
 packages:
+
+  '@alcalzone/ansi-tokenize@0.1.3':
+    resolution: {integrity: sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==}
+    engines: {node: '>=14.13.1'}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -154,6 +183,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -448,6 +633,131 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    resolution: {integrity: sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    resolution: {integrity: sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    resolution: {integrity: sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    resolution: {integrity: sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    resolution: {integrity: sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==}
+    cpu: [x64]
+    os: [win32]
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -581,8 +891,14 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -611,10 +927,16 @@ packages:
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
 
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
+
+  '@types/react@18.3.28':
+    resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
@@ -782,6 +1104,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -795,9 +1146,24 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -841,6 +1207,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
@@ -851,6 +1221,10 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -895,6 +1269,16 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -917,9 +1301,17 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
@@ -933,8 +1325,36 @@ packages:
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  cli-boxes@3.0.0:
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
+  cli-truncate@4.0.0:
+    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
+    engines: {node: '>=18'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -949,11 +1369,26 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1002,6 +1437,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -1035,6 +1474,9 @@ packages:
   electron-to-chromium@1.5.346:
     resolution: {integrity: sha512-3PGbvVwt9AppQsta0Kuq5DIcSj7aQfDfCVS7KnV3nhXEDtuJVRS7kK28Q+qy5KRkQ4bICV4xOaXNeUaXe78dDg==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
@@ -1045,6 +1487,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1062,6 +1508,9 @@ packages:
     resolution: {integrity: sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1078,15 +1527,27 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.46.1:
+    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
+
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1238,6 +1699,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
@@ -1282,6 +1747,9 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -1292,6 +1760,11 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1314,6 +1787,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -1446,6 +1923,30 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
+  ink-spinner@5.0.0:
+    resolution: {integrity: sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA==}
+    engines: {node: '>=14.16'}
+    peerDependencies:
+      ink: '>=4.0.0'
+      react: '>=18.0.0'
+
+  ink@5.2.1:
+    resolution: {integrity: sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      react: '>=18.0.0'
+      react-devtools-core: ^4.19.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
@@ -1509,6 +2010,14 @@ packages:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
 
+  is-fullwidth-code-point@4.0.0:
+    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
+    engines: {node: '>=12'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -1519,6 +2028,11 @@ packages:
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-in-ci@1.0.0:
+    resolution: {integrity: sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -1590,8 +2104,15 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
@@ -1716,6 +2237,17 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -1729,6 +2261,9 @@ packages:
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -1863,6 +2398,10 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1873,8 +2412,14 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -1961,6 +2506,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   oniguruma-parser@0.12.2:
     resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
 
@@ -1996,6 +2545,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2006,6 +2559,13 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2018,9 +2578,34 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -2059,9 +2644,23 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-reconciler@0.29.2:
+    resolution: {integrity: sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^18.3.1
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
@@ -2122,6 +2721,10 @@ packages:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
 
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -2130,9 +2733,18 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rollup@4.60.3:
+    resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -2148,6 +2760,9 @@ packages:
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2209,6 +2824,20 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  slice-ansi@5.0.0:
+    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
+    engines: {node: '>=12'}
+
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2226,9 +2855,23 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
 
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -2256,6 +2899,10 @@ packages:
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
   strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
@@ -2267,6 +2914,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -2287,6 +2937,11 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2302,13 +2957,42 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2322,15 +3006,41 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
   tsconfig-paths@3.15.0:
     resolution: {integrity: sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -2359,6 +3069,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -2418,6 +3131,79 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.2:
+    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -2442,9 +3228,34 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  widest-line@5.0.0:
+    resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
+    engines: {node: '>=18'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2457,6 +3268,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -2471,6 +3285,11 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@alcalzone/ansi-tokenize@0.1.3':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 4.0.0
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -2588,6 +3407,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
@@ -2855,6 +3752,81 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    optional: true
+
   '@rtsao/scc@1.1.0': {}
 
   '@shikijs/core@4.0.2':
@@ -2980,9 +3952,16 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -3010,9 +3989,16 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/prop-types@15.7.15': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
+
+  '@types/react@18.3.28':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
 
   '@types/react@19.2.14':
     dependencies:
@@ -3174,6 +4160,48 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3187,9 +4215,19 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  any-promise@1.3.0: {}
 
   argparse@1.0.10:
     dependencies:
@@ -3266,11 +4304,15 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assertion-error@2.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   astring@1.9.0: {}
 
   async-function@1.0.0: {}
+
+  auto-bind@5.0.1: {}
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -3309,6 +4351,13 @@ snapshots:
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  bundle-require@5.1.0(esbuild@0.27.7):
+    dependencies:
+      esbuild: 0.27.7
+      load-tsconfig: 0.2.5
+
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -3332,10 +4381,20 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -3345,7 +4404,30 @@ snapshots:
 
   character-reference-invalid@2.0.1: {}
 
+  check-error@2.1.3: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  cli-boxes@3.0.0: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
+  cli-spinners@2.9.2: {}
+
+  cli-truncate@4.0.0:
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 7.2.0
+
   client-only@0.0.1: {}
+
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
 
   collapse-white-space@2.1.0: {}
 
@@ -3357,9 +4439,17 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@4.1.1: {}
+
   concat-map@0.0.1: {}
 
+  confbox@0.1.8: {}
+
+  consola@3.4.2: {}
+
   convert-source-map@2.0.0: {}
+
+  convert-to-spaces@2.0.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -3403,6 +4493,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -3437,6 +4529,8 @@ snapshots:
 
   electron-to-chromium@1.5.346: {}
 
+  emoji-regex@10.6.0: {}
+
   emoji-regex@9.2.2: {}
 
   enhanced-resolve@5.21.0:
@@ -3445,6 +4539,8 @@ snapshots:
       tapable: 2.3.3
 
   entities@6.0.1: {}
+
+  environment@1.1.0: {}
 
   es-abstract@1.24.2:
     dependencies:
@@ -3526,6 +4622,8 @@ snapshots:
       iterator.prototype: 1.1.5
       math-intrinsics: 1.1.0
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -3547,6 +4645,8 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  es-toolkit@1.46.1: {}
+
   esast-util-from-estree@2.0.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
@@ -3561,7 +4661,38 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
   escalade@3.2.0: {}
+
+  escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
 
@@ -3805,6 +4936,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  expect-type@1.3.0: {}
+
   extend-shallow@2.0.1:
     dependencies:
       is-extendable: 0.1.1
@@ -3846,6 +4979,12 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      rollup: 4.60.3
+
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.4.2
@@ -3856,6 +4995,9 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -3875,6 +5017,8 @@ snapshots:
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-east-asian-width@1.5.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4074,6 +5218,47 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@5.0.0: {}
+
+  ink-spinner@5.0.0(ink@5.2.1(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      cli-spinners: 2.9.2
+      ink: 5.2.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+
+  ink@5.2.1(@types/react@18.3.28)(react@18.3.1):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.1.3
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 3.0.0
+      cli-cursor: 4.0.0
+      cli-truncate: 4.0.0
+      code-excerpt: 4.0.0
+      es-toolkit: 1.46.1
+      indent-string: 5.0.0
+      is-in-ci: 1.0.0
+      patch-console: 2.0.0
+      react: 18.3.1
+      react-reconciler: 0.29.2(react@18.3.1)
+      scheduler: 0.23.2
+      signal-exit: 3.0.7
+      slice-ansi: 7.1.2
+      stack-utils: 2.0.6
+      string-width: 7.2.0
+      type-fest: 4.41.0
+      widest-line: 5.0.0
+      wrap-ansi: 9.0.2
+      ws: 8.20.0
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   inline-style-parser@0.2.7: {}
 
   internal-slot@1.1.0:
@@ -4143,6 +5328,12 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-fullwidth-code-point@4.0.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -4156,6 +5347,8 @@ snapshots:
       is-extglob: 2.1.1
 
   is-hexadecimal@2.0.1: {}
+
+  is-in-ci@1.0.0: {}
 
   is-map@2.0.3: {}
 
@@ -4224,7 +5417,11 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  joycon@3.1.1: {}
+
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@3.14.2:
     dependencies:
@@ -4322,6 +5519,12 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  load-tsconfig@0.2.5: {}
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -4333,6 +5536,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -4658,6 +5863,8 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mimic-fn@2.1.0: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -4668,7 +5875,20 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   ms@2.1.3: {}
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
 
   nanoid@3.3.12: {}
 
@@ -4770,6 +5990,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   oniguruma-parser@0.12.2: {}
 
   oniguruma-to-es@4.3.6:
@@ -4821,11 +6045,17 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  patch-console@2.0.0: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -4833,7 +6063,23 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.2
+      pathe: 2.0.3
+
   possible-typed-array-names@1.1.0: {}
+
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.13)(yaml@2.8.3):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.6.1
+      postcss: 8.5.13
+      yaml: 2.8.3
 
   postcss-selector-parser@6.0.10:
     dependencies:
@@ -4873,7 +6119,19 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-reconciler@0.29.2(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
   react@19.2.4: {}
+
+  readdirp@4.1.2: {}
 
   recma-build-jsx@1.0.0:
     dependencies:
@@ -4992,6 +6250,8 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
+  resolve-from@5.0.0: {}
+
   resolve-pkg-maps@1.0.0: {}
 
   resolve@2.0.0-next.6:
@@ -5003,7 +6263,43 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
   reusify@1.1.0: {}
+
+  rollup@4.60.3:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.3
+      '@rollup/rollup-android-arm64': 4.60.3
+      '@rollup/rollup-darwin-arm64': 4.60.3
+      '@rollup/rollup-darwin-x64': 4.60.3
+      '@rollup/rollup-freebsd-arm64': 4.60.3
+      '@rollup/rollup-freebsd-x64': 4.60.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.3
+      '@rollup/rollup-linux-arm64-gnu': 4.60.3
+      '@rollup/rollup-linux-arm64-musl': 4.60.3
+      '@rollup/rollup-linux-loong64-gnu': 4.60.3
+      '@rollup/rollup-linux-loong64-musl': 4.60.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.3
+      '@rollup/rollup-linux-ppc64-musl': 4.60.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.3
+      '@rollup/rollup-linux-riscv64-musl': 4.60.3
+      '@rollup/rollup-linux-s390x-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-musl': 4.60.3
+      '@rollup/rollup-openbsd-x64': 4.60.3
+      '@rollup/rollup-openharmony-arm64': 4.60.3
+      '@rollup/rollup-win32-arm64-msvc': 4.60.3
+      '@rollup/rollup-win32-ia32-msvc': 4.60.3
+      '@rollup/rollup-win32-x64-gnu': 4.60.3
+      '@rollup/rollup-win32-x64-msvc': 4.60.3
+      fsevents: 2.3.3
 
   run-parallel@1.2.0:
     dependencies:
@@ -5027,6 +6323,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   scheduler@0.27.0: {}
 
@@ -5138,6 +6438,20 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
+
+  slice-ansi@5.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 4.0.0
+
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
@@ -5148,10 +6462,24 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
 
   string.prototype.includes@2.0.1:
     dependencies:
@@ -5208,11 +6536,19 @@ snapshots:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
   strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   style-to-js@1.1.21:
     dependencies:
@@ -5229,6 +6565,16 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.16
+      ts-interface-checker: 0.1.13
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -5239,14 +6585,34 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tree-kill@1.2.2: {}
 
   trim-lines@3.0.1: {}
 
@@ -5255,6 +6621,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-interface-checker@0.1.13: {}
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -5265,9 +6633,39 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.13)(typescript@5.9.3)(yaml@2.8.3):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.13)(yaml@2.8.3)
+      resolve-from: 5.0.0
+      rollup: 4.60.3
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.13
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@4.41.0: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -5314,6 +6712,8 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
+
+  ufo@1.6.4: {}
 
   unbox-primitive@1.1.0:
     dependencies:
@@ -5423,6 +6823,84 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.13
+      rollup: 4.60.3
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 20.19.39
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      yaml: 2.8.3
+
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.16
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.2(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@20.19.39)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 20.19.39
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   web-namespaces@2.0.1: {}
 
   which-boxed-primitive@1.1.1:
@@ -5470,13 +6948,32 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  widest-line@5.0.0:
+    dependencies:
+      string-width: 7.2.0
+
   word-wrap@1.2.5: {}
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  ws@8.20.0: {}
 
   yallist@3.1.1: {}
 
   yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
+
+  yoga-layout@3.2.1: {}
 
   zod-validation-error@4.0.2(zod@4.4.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - 'packages/*'
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/src/content/docs/getting-started.mdx
+++ b/src/content/docs/getting-started.mdx
@@ -1,66 +1,63 @@
 ---
 title: Getting Started
-description: Welcome to Sanghel Playbook — a living reference of patterns and decisions.
+description: Bienvenido a sanghel-playbook — patrones, decisiones de componentes y lecciones de software en producción, instalables desde la terminal.
 order: 1
 ---
 
 # Getting Started
 
-Welcome to **Sanghel Playbook**. This is a living document where I capture patterns,
-component decisions, and lessons learned building production software.
+Bienvenido a **Sanghel Playbook** — un catálogo vivo de patrones, configuraciones y guías que uso en proyectos de producción.
 
-## What you'll find here
+Puedes consumirlo de dos formas:
 
-- Component patterns and design decisions
-- Architecture notes and tradeoffs
-- Code snippets with context
+---
 
-## Running locally
+## CLI/TUI (recomendado)
 
-Clone the repo and start the dev server:
+Instala patrones directamente en tu proyecto desde la terminal, sin necesidad de copiar código manualmente.
 
 ```bash
-git clone https://github.com/Sanghel/sanghel-playbook
-cd sanghel-playbook
-pnpm install
-pnpm dev
+npx sanghel-playbook
 ```
 
-Then open [http://localhost:3000](http://localhost:3000).
+Al ejecutarlo, aparece una TUI interactiva con dos modos:
 
-## Adding a doc
+- **Crear nuevo proyecto** — scaffoldea React + Vite, Next.js o Astro con las herramientas oficiales, y luego ofrece aplicar patrones del catálogo encima.
+- **Añadir a proyecto existente** — navega el catálogo por categoría, selecciona los items que quieres (con espacio), y los instala en tu proyecto actual.
 
-Create a `.mdx` file inside `src/content/docs/`:
+El CLI detecta automáticamente tu package manager (`pnpm`, `yarn` o `npm`) e instala las dependencias necesarias.
 
-```mdx
+### ¿Qué instala?
+
+Cada item del catálogo puede instalar:
+- Archivos de código (hooks, componentes, schemas)
+- Guías y reglas en markdown
+- Dependencias npm requeridas
+
 ---
-title: My Topic
-description: A short description.
-order: 2
+
+## Documentación navegable (este site)
+
+Explora los patrones con contexto completo: por qué se usan, cuándo aplicarlos, y ejemplos de código. Usa el sidebar para navegar por categoría.
+
 ---
 
-# My Topic
+## Catálogo actual
 
-Write your content here.
-```
+El catálogo crece con cada nuevo patrón documentado. Actualmente incluye:
 
-<Callout variant="tip">
-  Use frontmatter `order` to control the position of a doc in the sidebar.
-</Callout>
+- **React** — patrones de componentes y formularios
+- **Next.js** — server actions, middleware, API routes, sessions
+- **Astro** — islands, routing, content collections
+- **Rules & Guides** — GitHub Flow, Deploy Guide (Vercel)
 
-<Callout variant="warning">
-  Always include a `title` in your frontmatter — the sidebar uses it to build navigation.
-</Callout>
+---
 
-## Syntax highlighting
+## Contribuir al catálogo
 
-Code blocks use Shiki with the `github-dark` theme:
+Para añadir un nuevo item:
 
-```typescript
-function greet(name: string): string {
-  return `Hello, ${name}!`
-}
-
-const message = greet('world')
-console.log(message)
-```
+1. Crear `catalog/{categoria}/{id}/manifest.json` con la metadata
+2. Añadir los archivos fuente en `catalog/{categoria}/{id}/files/`
+3. Crear la doc en `src/content/docs/catalog/{categoria}/{id}.mdx`
+4. Abrir un PR — catálogo y docs se actualizan en el mismo commit

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "packages"]
 }


### PR DESCRIPTION
## Summary

Transforma sanghel-playbook en un monorepo con un CLI/TUI público:

- `npx sanghel-playbook` lanza una TUI interactiva con Ink 5 + React 18
- **Modo crear** — scaffoldea React+Vite, Next.js o Astro con las herramientas oficiales
- **Modo añadir** — navega el catálogo por categoría, selecciona items con espacio, instala archivos + deps
- Detecta automáticamente pnpm/yarn/npm
- Fetcha catálogo desde GitHub raw en runtime

## Cambios principales

- `packages/cli/` — paquete npm (`sanghel-playbook`) con TUI completa
  - `lib/fetcher.ts`, `installer.ts`, `package-manager.ts`, `scaffolder.ts` (TDD, 32 tests)
  - `commands/add.ts`, `commands/create.ts`
  - `ui/MainMenu`, `StackMenu`, `CategoryMenu`, `ItemSelect`, `InstallProgress`
  - `src/index.tsx` — App state machine
- `catalog/` — estructura de catálogo con manifests para `github-flow` y `deploy-guide`
- `getting-started.mdx` — actualizado con instrucciones del CLI
- `tsconfig.json` — excluye `packages/` del type-check de Next.js

## Test Plan

- [ ] Site desplegado en Vercel sin errores de build
- [ ] `npx sanghel-playbook` muestra menú principal
- [ ] Flujo "añadir → Rules & Guides → GitHub Flow" instala el archivo correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)