### PR TITLE
feat(cli): capturar nombre de proyecto en el TUI

### DIFF
--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { render, Box, Text, useApp } from 'ink'
 import { MainMenu } from './ui/MainMenu.js'
 import { StackMenu } from './ui/StackMenu.js'
+import { ProjectNameInput } from './ui/ProjectNameInput.js'
 import { CategoryMenu } from './ui/CategoryMenu.js'
 import { ItemSelect } from './ui/ItemSelect.js'
 import { InstallProgress } from './ui/InstallProgress.js'
@@ -13,6 +14,7 @@ import type { Stack } from './commands/create.js'
 type Screen =
   | { id: 'main-menu' }
   | { id: 'stack-menu' }
+  | { id: 'project-name'; stack: Stack }
   | { id: 'loading'; message: string }
   | { id: 'category-menu'; categories: CategoryRef[] }
   | { id: 'item-select'; category: CategoryRef; items: ManifestItem[] }
@@ -36,18 +38,21 @@ function App() {
     []
   )
 
+  const handleStackSelect = useCallback((stack: Stack) => {
+    setScreen({ id: 'project-name', stack })
+  }, [])
+
   // spawnSync with stdio:'inherit' conflicts with Ink's TTY control.
   // Exit Ink first, defer createProject to let Ink finish teardown, then scaffold.
-  const handleStackSelect = useCallback((stack: Stack) => {
+  const handleProjectNameConfirm = useCallback((stack: Stack, name: string) => {
     exit()
     setImmediate(() => {
-      const name = `my-${stack}-app`
       const ok = createProject(stack, name)
       if (!ok) {
         console.error('\n✗ Error al crear el proyecto.')
         process.exit(1)
       } else {
-        console.log(`\n✓ Proyecto creado. Entra al directorio y corre npx sanghel-playbook para añadir patrones.`)
+        console.log(`\n✓ Proyecto "${name}" creado. Entra al directorio y corre npx sanghel-playbook para añadir patrones.`)
       }
     })
   }, [exit])
@@ -111,6 +116,16 @@ function App() {
       <StackMenu
         onSelect={handleStackSelect}
         onBack={() => setScreen({ id: 'main-menu' })}
+      />
+    )
+  }
+
+  if (screen.id === 'project-name') {
+    return (
+      <ProjectNameInput
+        stack={screen.stack}
+        onConfirm={(name) => handleProjectNameConfirm(screen.stack, name)}
+        onBack={() => setScreen({ id: 'stack-menu' })}
       />
     )
   }

--- a/packages/cli/src/ui/ProjectNameInput.tsx
+++ b/packages/cli/src/ui/ProjectNameInput.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import type { Stack } from '../commands/create.js'
+
+interface Props {
+  stack: Stack
+  onConfirm: (name: string) => void
+  onBack: () => void
+}
+
+const STACK_DEFAULTS: Record<Stack, string> = {
+  'react-vite': 'my-react-app',
+  'nextjs': 'my-next-app',
+  'astro': 'my-astro-app',
+}
+
+export function ProjectNameInput({ stack, onConfirm, onBack }: Props) {
+  const [value, setValue] = useState(STACK_DEFAULTS[stack])
+
+  useInput((input, key) => {
+    if (key.return) {
+      const name = value.trim()
+      if (name) onConfirm(name)
+      return
+    }
+    if (key.escape) {
+      onBack()
+      return
+    }
+    if (key.backspace || key.delete) {
+      setValue((v) => v.slice(0, -1))
+      return
+    }
+    if (input && !key.ctrl && !key.meta) {
+      setValue((v) => v + input)
+    }
+  })
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        Nuevo proyecto — nombre del proyecto
+      </Text>
+      <Text> </Text>
+      <Box>
+        <Text dimColor>{'> '}</Text>
+        <Text color="white">{value}</Text>
+        <Text color="green">{'█'}</Text>
+      </Box>
+      <Text> </Text>
+      <Text dimColor>enter confirmar  esc volver</Text>
+    </Box>
+  )
+}


### PR DESCRIPTION
## Cambios
- Nuevo estado `project-name` en la máquina de estados
- Nuevo componente `ProjectNameInput` con input manual via `useInput` (sin dependencias extra)
- El nombre tiene valor por defecto según el stack elegido (`my-react-app`, `my-next-app`, `my-astro-app`)
- Permite editar con teclado (backspace funciona), Enter confirma, Esc vuelve a StackMenu

## Testing
- ✅ Build exitoso (`pnpm build`)
- ✅ Sin errores TypeScript

Closes #90
Related to #89