### PR TITLE
feat(cli): extras del catálogo al crear proyecto

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -14,6 +14,14 @@ export async function loadCategoryItems(categoryId: string): Promise<ManifestIte
   return Promise.all(catIndex.items.map((id) => fetchManifest(categoryId, id)))
 }
 
+export async function loadItemsByStack(stack: string): Promise<ManifestItem[]> {
+  const categories = await loadCatalog()
+  const allItemsNested = await Promise.all(
+    categories.map((cat) => loadCategoryItems(cat.id).catch(() => [] as ManifestItem[]))
+  )
+  return allItemsNested.flat().filter((item) => item.tags.includes(stack))
+}
+
 export async function runInstall(
   manifests: ManifestItem[],
   cwd: string,

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -1,3 +1,4 @@
+import path from 'path'
 import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { render, Box, Text, useApp } from 'ink'
 import { MainMenu } from './ui/MainMenu.js'
@@ -6,7 +7,7 @@ import { ProjectNameInput } from './ui/ProjectNameInput.js'
 import { CategoryMenu } from './ui/CategoryMenu.js'
 import { ItemSelect } from './ui/ItemSelect.js'
 import { InstallProgress } from './ui/InstallProgress.js'
-import { loadCatalog, loadCategoryItems, runInstall } from './commands/add.js'
+import { loadCatalog, loadCategoryItems, loadItemsByStack, runInstall } from './commands/add.js'
 import { createProject } from './commands/create.js'
 import type { CategoryRef, ManifestItem, InstallStep } from './types.js'
 import type { Stack } from './commands/create.js'
@@ -16,6 +17,7 @@ type Screen =
   | { id: 'stack-menu' }
   | { id: 'project-name'; stack: Stack }
   | { id: 'loading'; message: string }
+  | { id: 'extra-select'; stack: Stack; projectName: string; items: ManifestItem[] }
   | { id: 'category-menu'; categories: CategoryRef[] }
   | { id: 'item-select'; category: CategoryRef; items: ManifestItem[] }
   | { id: 'install-progress'; steps: InstallStep[]; done: boolean; docsUrl: string | null }
@@ -42,18 +44,55 @@ function App() {
     setScreen({ id: 'project-name', stack })
   }, [])
 
-  // spawnSync with stdio:'inherit' conflicts with Ink's TTY control.
-  // Exit Ink first, defer createProject to let Ink finish teardown, then scaffold.
   const handleProjectNameConfirm = useCallback((stack: Stack, name: string) => {
+    setScreen({ id: 'loading', message: 'Cargando extras del catálogo...' })
+    loadItemsByStack(stack)
+      .then(async (items) => {
+        // Fall back to all catalog items if none match this stack
+        if (items.length === 0) {
+          const categories = await loadCatalog()
+          const all = await Promise.all(categories.map((c) => loadCategoryItems(c.id).catch(() => [] as ManifestItem[])))
+          items = all.flat()
+        }
+        if (items.length === 0) {
+          handleCreateWithExtras(stack, name, [])
+        } else {
+          setScreen({ id: 'extra-select', stack, projectName: name, items })
+        }
+      })
+      .catch(() => {
+        handleCreateWithExtras(stack, name, [])
+      })
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // spawnSync with stdio:'inherit' conflicts with Ink's TTY control.
+  // Exit Ink first, defer createProject to let Ink finish teardown, then scaffold + extras.
+  const handleCreateWithExtras = useCallback((stack: Stack, projectName: string, extras: ManifestItem[]) => {
     exit()
     setImmediate(() => {
-      const ok = createProject(stack, name)
-      if (!ok) {
-        console.error('\n✗ Error al crear el proyecto.')
-        process.exit(1)
-      } else {
-        console.log(`\n✓ Proyecto "${name}" creado. Entra al directorio y corre npx sanghel-playbook para añadir patrones.`)
-      }
+      void (async () => {
+        const ok = createProject(stack, projectName)
+        if (!ok) {
+          console.error('\n✗ Error al crear el proyecto.')
+          process.exit(1)
+          return
+        }
+
+        if (extras.length > 0) {
+          const projectCwd = path.join(process.cwd(), projectName)
+          console.log('\nInstalando extras...')
+          try {
+            await runInstall(extras, projectCwd, (step) => {
+              const icon = step.status === 'done' ? '✓' : step.status === 'error' ? '✗' : step.status === 'skipped' ? '⊘' : '…'
+              console.log(`  ${icon} ${step.label}`)
+            })
+          } catch (err) {
+            console.error(`  ✗ Error instalando extras: ${String(err)}`)
+          }
+        }
+
+        console.log(`\n✓ Proyecto "${projectName}" listo. Entra al directorio: cd ${projectName}`)
+      })()
     })
   }, [exit])
 
@@ -76,6 +115,7 @@ function App() {
   }, [])
 
   const handleInstall = useCallback(async (manifests: ManifestItem[]) => {
+    if (manifests.length === 0) return
     const steps: InstallStep[] = []
     setScreen({ id: 'install-progress', steps: [], done: false, docsUrl: null })
 
@@ -135,6 +175,19 @@ function App() {
       <Box padding={1}>
         <Text color="cyan">{screen.message}</Text>
       </Box>
+    )
+  }
+
+  if (screen.id === 'extra-select') {
+    const { stack, projectName, items } = screen
+    return (
+      <ItemSelect
+        items={items}
+        categoryLabel={`Extras para ${stack} — "${projectName}"`}
+        onInstall={(selected) => handleCreateWithExtras(stack, projectName, selected)}
+        onBack={() => setScreen({ id: 'project-name', stack })}
+        allowEmpty
+      />
     )
   }
 

--- a/packages/cli/src/ui/ItemSelect.tsx
+++ b/packages/cli/src/ui/ItemSelect.tsx
@@ -7,9 +7,10 @@ interface Props {
   categoryLabel: string
   onInstall: (selected: ManifestItem[]) => void
   onBack: () => void
+  allowEmpty?: boolean
 }
 
-export function ItemSelect({ items, categoryLabel, onInstall, onBack }: Props) {
+export function ItemSelect({ items, categoryLabel, onInstall, onBack, allowEmpty = false }: Props) {
   const [cursor, setCursor] = useState(0)
   const [selected, setSelected] = useState<Set<string>>(new Set())
 
@@ -31,7 +32,7 @@ export function ItemSelect({ items, categoryLabel, onInstall, onBack }: Props) {
     }
     if (key.return) {
       const toInstall = items.filter((item) => selected.has(item.id))
-      if (toInstall.length > 0) onInstall(toInstall)
+      if (toInstall.length > 0 || allowEmpty) onInstall(toInstall)
     }
     if (key.escape) onBack()
   })
@@ -55,7 +56,9 @@ export function ItemSelect({ items, categoryLabel, onInstall, onBack }: Props) {
         </Box>
       ))}
       <Text> </Text>
-      <Text dimColor>↑↓ navegar  espacio seleccionar  enter instalar  esc volver</Text>
+      <Text dimColor>
+        ↑↓ navegar  espacio seleccionar  enter {allowEmpty && selected.size === 0 ? 'continuar sin extras' : 'instalar'}  esc volver
+      </Text>
       {selected.size > 0 && (
         <Text color="yellow">{selected.size} item(s) seleccionado(s)</Text>
       )}


### PR DESCRIPTION
## Cambios
- Nuevo estado `extra-select` en el flujo create (entre ingresar nombre y scaffold)
- `loadItemsByStack(stack)` en `commands/add.ts` — filtra items del catálogo por tag de stack, con fallback a todos los items si ninguno hace match
- `ItemSelect` recibe prop `allowEmpty` para permitir continuar sin seleccionar nada
- Post-scaffold: instala extras en el directorio del proyecto recién creado vía `runInstall`
- Si el catálogo no está disponible (error de red), continúa al scaffold silenciosamente

## Testing
- ✅ Build exitoso (`pnpm build`)
- ✅ Sin errores TypeScript

Closes #92
Related to #89