### PR TITLE
FASE 1: CLI — Seleccionar e instalar packages extras al crear proyecto

### DIFF
--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -14,6 +14,14 @@ export async function loadCategoryItems(categoryId: string): Promise<ManifestIte
   return Promise.all(catIndex.items.map((id) => fetchManifest(categoryId, id)))
 }
 
+export async function loadItemsByStack(stack: string): Promise<ManifestItem[]> {
+  const categories = await loadCatalog()
+  const allItemsNested = await Promise.all(
+    categories.map((cat) => loadCategoryItems(cat.id).catch(() => [] as ManifestItem[]))
+  )
+  return allItemsNested.flat().filter((item) => item.tags.includes(stack))
+}
+
 export async function runInstall(
   manifests: ManifestItem[],
   cwd: string,

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { render, Box, Text, useApp } from 'ink'
 import { MainMenu } from './ui/MainMenu.js'
 import { StackMenu } from './ui/StackMenu.js'
+import { ProjectNameInput } from './ui/ProjectNameInput.js'
 import { CategoryMenu } from './ui/CategoryMenu.js'
 import { ItemSelect } from './ui/ItemSelect.js'
 import { InstallProgress } from './ui/InstallProgress.js'
@@ -13,6 +14,7 @@ import type { Stack } from './commands/create.js'
 type Screen =
   | { id: 'main-menu' }
   | { id: 'stack-menu' }
+  | { id: 'project-name'; stack: Stack }
   | { id: 'loading'; message: string }
   | { id: 'category-menu'; categories: CategoryRef[] }
   | { id: 'item-select'; category: CategoryRef; items: ManifestItem[] }
@@ -36,18 +38,21 @@ function App() {
     []
   )
 
+  const handleStackSelect = useCallback((stack: Stack) => {
+    setScreen({ id: 'project-name', stack })
+  }, [])
+
   // spawnSync with stdio:'inherit' conflicts with Ink's TTY control.
   // Exit Ink first, defer createProject to let Ink finish teardown, then scaffold.
-  const handleStackSelect = useCallback((stack: Stack) => {
+  const handleProjectNameConfirm = useCallback((stack: Stack, name: string) => {
     exit()
     setImmediate(() => {
-      const name = `my-${stack}-app`
       const ok = createProject(stack, name)
       if (!ok) {
         console.error('\n✗ Error al crear el proyecto.')
         process.exit(1)
       } else {
-        console.log(`\n✓ Proyecto creado. Entra al directorio y corre npx sanghel-playbook para añadir patrones.`)
+        console.log(`\n✓ Proyecto "${name}" creado. Entra al directorio y corre npx sanghel-playbook para añadir patrones.`)
       }
     })
   }, [exit])
@@ -111,6 +116,16 @@ function App() {
       <StackMenu
         onSelect={handleStackSelect}
         onBack={() => setScreen({ id: 'main-menu' })}
+      />
+    )
+  }
+
+  if (screen.id === 'project-name') {
+    return (
+      <ProjectNameInput
+        stack={screen.stack}
+        onConfirm={(name) => handleProjectNameConfirm(screen.stack, name)}
+        onBack={() => setScreen({ id: 'stack-menu' })}
       />
     )
   }

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -1,3 +1,4 @@
+import path from 'path'
 import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { render, Box, Text, useApp } from 'ink'
 import { MainMenu } from './ui/MainMenu.js'
@@ -6,7 +7,7 @@ import { ProjectNameInput } from './ui/ProjectNameInput.js'
 import { CategoryMenu } from './ui/CategoryMenu.js'
 import { ItemSelect } from './ui/ItemSelect.js'
 import { InstallProgress } from './ui/InstallProgress.js'
-import { loadCatalog, loadCategoryItems, runInstall } from './commands/add.js'
+import { loadCatalog, loadCategoryItems, loadItemsByStack, runInstall } from './commands/add.js'
 import { createProject } from './commands/create.js'
 import type { CategoryRef, ManifestItem, InstallStep } from './types.js'
 import type { Stack } from './commands/create.js'
@@ -16,6 +17,7 @@ type Screen =
   | { id: 'stack-menu' }
   | { id: 'project-name'; stack: Stack }
   | { id: 'loading'; message: string }
+  | { id: 'extra-select'; stack: Stack; projectName: string; items: ManifestItem[] }
   | { id: 'category-menu'; categories: CategoryRef[] }
   | { id: 'item-select'; category: CategoryRef; items: ManifestItem[] }
   | { id: 'install-progress'; steps: InstallStep[]; done: boolean; docsUrl: string | null }
@@ -42,18 +44,55 @@ function App() {
     setScreen({ id: 'project-name', stack })
   }, [])
 
-  // spawnSync with stdio:'inherit' conflicts with Ink's TTY control.
-  // Exit Ink first, defer createProject to let Ink finish teardown, then scaffold.
   const handleProjectNameConfirm = useCallback((stack: Stack, name: string) => {
+    setScreen({ id: 'loading', message: 'Cargando extras del catálogo...' })
+    loadItemsByStack(stack)
+      .then(async (items) => {
+        // Fall back to all catalog items if none match this stack
+        if (items.length === 0) {
+          const categories = await loadCatalog()
+          const all = await Promise.all(categories.map((c) => loadCategoryItems(c.id).catch(() => [] as ManifestItem[])))
+          items = all.flat()
+        }
+        if (items.length === 0) {
+          handleCreateWithExtras(stack, name, [])
+        } else {
+          setScreen({ id: 'extra-select', stack, projectName: name, items })
+        }
+      })
+      .catch(() => {
+        handleCreateWithExtras(stack, name, [])
+      })
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // spawnSync with stdio:'inherit' conflicts with Ink's TTY control.
+  // Exit Ink first, defer createProject to let Ink finish teardown, then scaffold + extras.
+  const handleCreateWithExtras = useCallback((stack: Stack, projectName: string, extras: ManifestItem[]) => {
     exit()
     setImmediate(() => {
-      const ok = createProject(stack, name)
-      if (!ok) {
-        console.error('\n✗ Error al crear el proyecto.')
-        process.exit(1)
-      } else {
-        console.log(`\n✓ Proyecto "${name}" creado. Entra al directorio y corre npx sanghel-playbook para añadir patrones.`)
-      }
+      void (async () => {
+        const ok = createProject(stack, projectName)
+        if (!ok) {
+          console.error('\n✗ Error al crear el proyecto.')
+          process.exit(1)
+          return
+        }
+
+        if (extras.length > 0) {
+          const projectCwd = path.join(process.cwd(), projectName)
+          console.log('\nInstalando extras...')
+          try {
+            await runInstall(extras, projectCwd, (step) => {
+              const icon = step.status === 'done' ? '✓' : step.status === 'error' ? '✗' : step.status === 'skipped' ? '⊘' : '…'
+              console.log(`  ${icon} ${step.label}`)
+            })
+          } catch (err) {
+            console.error(`  ✗ Error instalando extras: ${String(err)}`)
+          }
+        }
+
+        console.log(`\n✓ Proyecto "${projectName}" listo. Entra al directorio: cd ${projectName}`)
+      })()
     })
   }, [exit])
 
@@ -76,6 +115,7 @@ function App() {
   }, [])
 
   const handleInstall = useCallback(async (manifests: ManifestItem[]) => {
+    if (manifests.length === 0) return
     const steps: InstallStep[] = []
     setScreen({ id: 'install-progress', steps: [], done: false, docsUrl: null })
 
@@ -135,6 +175,19 @@ function App() {
       <Box padding={1}>
         <Text color="cyan">{screen.message}</Text>
       </Box>
+    )
+  }
+
+  if (screen.id === 'extra-select') {
+    const { stack, projectName, items } = screen
+    return (
+      <ItemSelect
+        items={items}
+        categoryLabel={`Extras para ${stack} — "${projectName}"`}
+        onInstall={(selected) => handleCreateWithExtras(stack, projectName, selected)}
+        onBack={() => setScreen({ id: 'project-name', stack })}
+        allowEmpty
+      />
     )
   }
 

--- a/packages/cli/src/ui/ItemSelect.tsx
+++ b/packages/cli/src/ui/ItemSelect.tsx
@@ -7,9 +7,10 @@ interface Props {
   categoryLabel: string
   onInstall: (selected: ManifestItem[]) => void
   onBack: () => void
+  allowEmpty?: boolean
 }
 
-export function ItemSelect({ items, categoryLabel, onInstall, onBack }: Props) {
+export function ItemSelect({ items, categoryLabel, onInstall, onBack, allowEmpty = false }: Props) {
   const [cursor, setCursor] = useState(0)
   const [selected, setSelected] = useState<Set<string>>(new Set())
 
@@ -31,7 +32,7 @@ export function ItemSelect({ items, categoryLabel, onInstall, onBack }: Props) {
     }
     if (key.return) {
       const toInstall = items.filter((item) => selected.has(item.id))
-      if (toInstall.length > 0) onInstall(toInstall)
+      if (toInstall.length > 0 || allowEmpty) onInstall(toInstall)
     }
     if (key.escape) onBack()
   })
@@ -55,7 +56,9 @@ export function ItemSelect({ items, categoryLabel, onInstall, onBack }: Props) {
         </Box>
       ))}
       <Text> </Text>
-      <Text dimColor>↑↓ navegar  espacio seleccionar  enter instalar  esc volver</Text>
+      <Text dimColor>
+        ↑↓ navegar  espacio seleccionar  enter {allowEmpty && selected.size === 0 ? 'continuar sin extras' : 'instalar'}  esc volver
+      </Text>
       {selected.size > 0 && (
         <Text color="yellow">{selected.size} item(s) seleccionado(s)</Text>
       )}

--- a/packages/cli/src/ui/ProjectNameInput.tsx
+++ b/packages/cli/src/ui/ProjectNameInput.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import type { Stack } from '../commands/create.js'
+
+interface Props {
+  stack: Stack
+  onConfirm: (name: string) => void
+  onBack: () => void
+}
+
+const STACK_DEFAULTS: Record<Stack, string> = {
+  'react-vite': 'my-react-app',
+  'nextjs': 'my-next-app',
+  'astro': 'my-astro-app',
+}
+
+export function ProjectNameInput({ stack, onConfirm, onBack }: Props) {
+  const [value, setValue] = useState(STACK_DEFAULTS[stack])
+
+  useInput((input, key) => {
+    if (key.return) {
+      const name = value.trim()
+      if (name) onConfirm(name)
+      return
+    }
+    if (key.escape) {
+      onBack()
+      return
+    }
+    if (key.backspace || key.delete) {
+      setValue((v) => v.slice(0, -1))
+      return
+    }
+    if (input && !key.ctrl && !key.meta) {
+      setValue((v) => v + input)
+    }
+  })
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        Nuevo proyecto — nombre del proyecto
+      </Text>
+      <Text> </Text>
+      <Box>
+        <Text dimColor>{'> '}</Text>
+        <Text color="white">{value}</Text>
+        <Text color="green">{'█'}</Text>
+      </Box>
+      <Text> </Text>
+      <Text dimColor>enter confirmar  esc volver</Text>
+    </Box>
+  )
+}


### PR DESCRIPTION
## Resumen
FASE 1 completada: el flujo de creación de proyectos ahora captura el nombre del proyecto en el TUI y ofrece un multi-select de extras del catálogo antes de hacer el scaffold.

## Tareas Completadas
- [x] Tarea 1.1: Capturar nombre de proyecto en el TUI (#90, PR #91)
- [x] Tarea 1.2 + 1.3 + 1.4: Multi-select de extras + instalación post-scaffold (#92, PR #93)

## Nuevo flujo create
```
MainMenu → StackMenu → ProjectNameInput → [loading extras] → ExtraSelect → scaffold + install extras
```

## Testing
- ✅ Build exitoso (`pnpm build`)
- ✅ Sin errores TypeScript
- ✅ Probado localmente: flujo completo sin extras y con extras seleccionados

## Cambios
- `packages/cli/src/ui/ProjectNameInput.tsx` — nuevo componente input de nombre
- `packages/cli/src/ui/ItemSelect.tsx` — prop `allowEmpty` para saltar selección
- `packages/cli/src/commands/add.ts` — `loadItemsByStack()` con fallback
- `packages/cli/src/index.tsx` — estados `project-name` y `extra-select`

Closes #89