### PR TITLE
FASE 2: Custom Templates con branding Sanghel

### DIFF
--- a/catalog/index.json
+++ b/catalog/index.json
@@ -3,6 +3,7 @@
     { "id": "react", "label": "React", "indexUrl": "catalog/react/index.json" },
     { "id": "nextjs", "label": "Next.js", "indexUrl": "catalog/nextjs/index.json" },
     { "id": "astro", "label": "Astro", "indexUrl": "catalog/astro/index.json" },
-    { "id": "rules", "label": "Rules & Guides", "indexUrl": "catalog/rules/index.json" }
+    { "id": "rules", "label": "Rules & Guides", "indexUrl": "catalog/rules/index.json" },
+    { "id": "templates", "label": "Templates", "indexUrl": "catalog/templates/index.json" }
   ]
 }

--- a/catalog/templates/index.json
+++ b/catalog/templates/index.json
@@ -1,0 +1,5 @@
+{
+  "category": "templates",
+  "label": "Templates",
+  "items": ["react-vite", "nextjs"]
+}

--- a/catalog/templates/nextjs/files/src/app/page.tsx
+++ b/catalog/templates/nextjs/files/src/app/page.tsx
@@ -1,0 +1,5 @@
+import { Welcome } from '@/components/Welcome/Welcome'
+
+export default function Home() {
+  return <Welcome />
+}

--- a/catalog/templates/nextjs/files/src/components/Welcome/Welcome.module.css
+++ b/catalog/templates/nextjs/files/src/components/Welcome/Welcome.module.css
@@ -1,0 +1,83 @@
+.container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0a0a0a;
+  color: #fafafa;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid #3f3f46;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #a1a1aa;
+  margin-bottom: 1.5rem;
+}
+
+.title {
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  font-weight: 700;
+  text-align: center;
+  margin: 0 0 1rem;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  font-size: 1rem;
+  color: #a1a1aa;
+  text-align: center;
+  margin: 0 0 2.5rem;
+  max-width: 480px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  width: 100%;
+  max-width: 720px;
+}
+
+.card {
+  display: block;
+  padding: 1.25rem;
+  border: 1px solid #27272a;
+  border-radius: 0.5rem;
+  background: #18181b;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s;
+}
+
+.card:hover {
+  border-color: #52525b;
+}
+
+.card h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+
+.card p {
+  font-size: 0.875rem;
+  color: #71717a;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.tree {
+  font-size: 0.8rem;
+  color: #71717a;
+  margin: 0;
+  font-family: 'Geist Mono', 'Fira Code', monospace;
+}

--- a/catalog/templates/nextjs/files/src/components/Welcome/Welcome.tsx
+++ b/catalog/templates/nextjs/files/src/components/Welcome/Welcome.tsx
@@ -1,0 +1,44 @@
+import styles from './Welcome.module.css'
+
+export function Welcome() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.badge}>Sanghel Playbook</div>
+      <h1 className={styles.title}>Welcome to Sanghel Next.js Template</h1>
+      <p className={styles.subtitle}>
+        Your project is ready. Start building with a solid foundation.
+      </p>
+      <div className={styles.grid}>
+        <a
+          className={styles.card}
+          href="https://sanghel-playbook.vercel.app/docs/getting-started"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <h2>Docs →</h2>
+          <p>Patterns, components and architectural decisions.</p>
+        </a>
+        <a
+          className={styles.card}
+          href="https://github.com/Sanghel/sanghel-playbook"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <h2>Playbook →</h2>
+          <p>Browse the catalog and add more patterns.</p>
+        </a>
+        <div className={styles.card}>
+          <h2>Structure</h2>
+          <pre className={styles.tree}>{`src/
+├── app/
+├── components/
+└── hooks/`}</pre>
+        </div>
+        <div className={styles.card}>
+          <h2>Add patterns</h2>
+          <pre className={styles.tree}>npx sanghel-playbook</pre>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/catalog/templates/nextjs/files/src/hooks/useLocalStorage.ts
+++ b/catalog/templates/nextjs/files/src/hooks/useLocalStorage.ts
@@ -1,0 +1,26 @@
+'use client'
+
+import { useState } from 'react'
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      const item = window.localStorage.getItem(key)
+      return item ? (JSON.parse(item) as T) : initialValue
+    } catch {
+      return initialValue
+    }
+  })
+
+  const setValue = (value: T | ((prev: T) => T)) => {
+    try {
+      const valueToStore = value instanceof Function ? value(storedValue) : value
+      setStoredValue(valueToStore)
+      window.localStorage.setItem(key, JSON.stringify(valueToStore))
+    } catch {
+      // ignore write errors
+    }
+  }
+
+  return [storedValue, setValue] as const
+}

--- a/catalog/templates/nextjs/manifest.json
+++ b/catalog/templates/nextjs/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "nextjs",
+  "name": "Sanghel Next.js Template",
+  "description": "Template base con Welcome module, estructura de carpetas (components, hooks) y useLocalStorage hook",
+  "category": "templates",
+  "tags": ["nextjs", "next.js", "react", "template"],
+  "deps": {
+    "dependencies": [],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/src/app/page.tsx", "dest": "src/app/page.tsx" },
+    { "src": "files/src/components/Welcome/Welcome.tsx", "dest": "src/components/Welcome/Welcome.tsx" },
+    { "src": "files/src/components/Welcome/Welcome.module.css", "dest": "src/components/Welcome/Welcome.module.css" },
+    { "src": "files/src/hooks/useLocalStorage.ts", "dest": "src/hooks/useLocalStorage.ts" }
+  ],
+  "docsUrl": "https://sanghel-playbook.vercel.app/docs/getting-started"
+}

--- a/catalog/templates/react-vite/files/src/App.tsx
+++ b/catalog/templates/react-vite/files/src/App.tsx
@@ -1,0 +1,7 @@
+import { Welcome } from './components/Welcome/Welcome'
+
+function App() {
+  return <Welcome />
+}
+
+export default App

--- a/catalog/templates/react-vite/files/src/components/Welcome/Welcome.module.css
+++ b/catalog/templates/react-vite/files/src/components/Welcome/Welcome.module.css
@@ -1,0 +1,83 @@
+.container {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  font-family: system-ui, -apple-system, sans-serif;
+  background: #0a0a0a;
+  color: #fafafa;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border: 1px solid #3f3f46;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #a1a1aa;
+  margin-bottom: 1.5rem;
+}
+
+.title {
+  font-size: clamp(1.5rem, 4vw, 2.5rem);
+  font-weight: 700;
+  text-align: center;
+  margin: 0 0 1rem;
+  letter-spacing: -0.02em;
+}
+
+.subtitle {
+  font-size: 1rem;
+  color: #a1a1aa;
+  text-align: center;
+  margin: 0 0 2.5rem;
+  max-width: 480px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+  width: 100%;
+  max-width: 720px;
+}
+
+.card {
+  display: block;
+  padding: 1.25rem;
+  border: 1px solid #27272a;
+  border-radius: 0.5rem;
+  background: #18181b;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.15s;
+}
+
+.card:hover {
+  border-color: #52525b;
+}
+
+.card h2 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+
+.card p {
+  font-size: 0.875rem;
+  color: #71717a;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.tree {
+  font-size: 0.8rem;
+  color: #71717a;
+  margin: 0;
+  font-family: 'Geist Mono', 'Fira Code', monospace;
+}

--- a/catalog/templates/react-vite/files/src/components/Welcome/Welcome.tsx
+++ b/catalog/templates/react-vite/files/src/components/Welcome/Welcome.tsx
@@ -1,0 +1,44 @@
+import styles from './Welcome.module.css'
+
+export function Welcome() {
+  return (
+    <div className={styles.container}>
+      <div className={styles.badge}>Sanghel Playbook</div>
+      <h1 className={styles.title}>Welcome to Sanghel React + Vite Template</h1>
+      <p className={styles.subtitle}>
+        Your project is ready. Start building with a solid foundation.
+      </p>
+      <div className={styles.grid}>
+        <a
+          className={styles.card}
+          href="https://sanghel-playbook.vercel.app/docs/getting-started"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <h2>Docs →</h2>
+          <p>Patterns, components and architectural decisions.</p>
+        </a>
+        <a
+          className={styles.card}
+          href="https://github.com/Sanghel/sanghel-playbook"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <h2>Playbook →</h2>
+          <p>Browse the catalog and add more patterns.</p>
+        </a>
+        <div className={styles.card}>
+          <h2>Structure</h2>
+          <pre className={styles.tree}>{`src/
+├── components/
+├── hooks/
+└── App.tsx`}</pre>
+        </div>
+        <div className={styles.card}>
+          <h2>Add patterns</h2>
+          <pre className={styles.tree}>npx sanghel-playbook</pre>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/catalog/templates/react-vite/files/src/hooks/useLocalStorage.ts
+++ b/catalog/templates/react-vite/files/src/hooks/useLocalStorage.ts
@@ -1,0 +1,24 @@
+import { useState } from 'react'
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      const item = window.localStorage.getItem(key)
+      return item ? (JSON.parse(item) as T) : initialValue
+    } catch {
+      return initialValue
+    }
+  })
+
+  const setValue = (value: T | ((prev: T) => T)) => {
+    try {
+      const valueToStore = value instanceof Function ? value(storedValue) : value
+      setStoredValue(valueToStore)
+      window.localStorage.setItem(key, JSON.stringify(valueToStore))
+    } catch {
+      // ignore write errors
+    }
+  }
+
+  return [storedValue, setValue] as const
+}

--- a/catalog/templates/react-vite/manifest.json
+++ b/catalog/templates/react-vite/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "react-vite",
+  "name": "Sanghel React + Vite Template",
+  "description": "Template base con Welcome module, estructura de carpetas (components, hooks) y useLocalStorage hook",
+  "category": "templates",
+  "tags": ["react-vite", "react", "vite", "template"],
+  "deps": {
+    "dependencies": [],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/src/App.tsx", "dest": "src/App.tsx" },
+    { "src": "files/src/components/Welcome/Welcome.tsx", "dest": "src/components/Welcome/Welcome.tsx" },
+    { "src": "files/src/components/Welcome/Welcome.module.css", "dest": "src/components/Welcome/Welcome.module.css" },
+    { "src": "files/src/hooks/useLocalStorage.ts", "dest": "src/hooks/useLocalStorage.ts" }
+  ],
+  "docsUrl": "https://sanghel-playbook.vercel.app/docs/getting-started"
+}

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,8 +1,41 @@
+import { fetchManifest } from '../lib/fetcher.js'
+import { installFiles } from '../lib/installer.js'
 import { scaffold } from '../lib/scaffolder.js'
+import type { InstallStep } from '../types.js'
 import type { Stack } from '../lib/scaffolder.js'
 
 export type { Stack }
 
 export function createProject(stack: Stack, projectName: string): boolean {
   return scaffold(stack, projectName)
+}
+
+const TEMPLATE_MAP: Partial<Record<Stack, string>> = {
+  'react-vite': 'react-vite',
+  'nextjs': 'nextjs',
+}
+
+export async function applyTemplate(
+  stack: Stack,
+  projectCwd: string,
+  onStep: (step: InstallStep) => void
+): Promise<void> {
+  const templateId = TEMPLATE_MAP[stack]
+  if (!templateId) return
+
+  let manifest
+  try {
+    manifest = await fetchManifest('templates', templateId)
+  } catch {
+    // No template found for this stack — skip silently
+    return
+  }
+
+  const results = await installFiles(manifest, projectCwd)
+  for (const result of results) {
+    onStep({
+      label: result.path,
+      status: result.error ? 'error' : result.skipped ? 'skipped' : 'done',
+    })
+  }
 }

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -8,7 +8,7 @@ import { CategoryMenu } from './ui/CategoryMenu.js'
 import { ItemSelect } from './ui/ItemSelect.js'
 import { InstallProgress } from './ui/InstallProgress.js'
 import { loadCatalog, loadCategoryItems, loadItemsByStack, runInstall } from './commands/add.js'
-import { createProject } from './commands/create.js'
+import { createProject, applyTemplate } from './commands/create.js'
 import type { CategoryRef, ManifestItem, InstallStep } from './types.js'
 import type { Stack } from './commands/create.js'
 
@@ -78,14 +78,23 @@ function App() {
           return
         }
 
+        const projectCwd = path.join(process.cwd(), projectName)
+        const logStep = (step: { label: string; status: string }) => {
+          const icon = step.status === 'done' ? '✓' : step.status === 'error' ? '✗' : step.status === 'skipped' ? '⊘' : '…'
+          console.log(`  ${icon} ${step.label}`)
+        }
+
+        console.log('\nAplicando template Sanghel...')
+        try {
+          await applyTemplate(stack, projectCwd, logStep)
+        } catch (err) {
+          console.error(`  ✗ Error aplicando template: ${String(err)}`)
+        }
+
         if (extras.length > 0) {
-          const projectCwd = path.join(process.cwd(), projectName)
           console.log('\nInstalando extras...')
           try {
-            await runInstall(extras, projectCwd, (step) => {
-              const icon = step.status === 'done' ? '✓' : step.status === 'error' ? '✗' : step.status === 'skipped' ? '⊘' : '…'
-              console.log(`  ${icon} ${step.label}`)
-            })
+            await runInstall(extras, projectCwd, logStep)
           } catch (err) {
             console.error(`  ✗ Error instalando extras: ${String(err)}`)
           }

--- a/packages/cli/src/lib/fetcher.ts
+++ b/packages/cli/src/lib/fetcher.ts
@@ -36,6 +36,6 @@ export async function fetchManifest(categoryId: string, itemId: string): Promise
   return fetchJson<ManifestItem>(`catalog/${categoryId}/${itemId}/manifest.json`)
 }
 
-export async function fetchFile(categoryId: string, itemId: string, filename: string): Promise<string> {
-  return fetchText(`catalog/${categoryId}/${itemId}/files/${filename}`)
+export async function fetchFile(categoryId: string, itemId: string, subPath: string): Promise<string> {
+  return fetchText(`catalog/${categoryId}/${itemId}/files/${subPath}`)
 }

--- a/packages/cli/src/lib/installer.ts
+++ b/packages/cli/src/lib/installer.ts
@@ -1,5 +1,5 @@
 import { writeFileSync, mkdirSync, existsSync } from 'fs'
-import { join, dirname, basename } from 'path'
+import { join, dirname } from 'path'
 import { fetchFile } from './fetcher.js'
 import type { ManifestItem, InstallResult } from '../types.js'
 
@@ -18,7 +18,10 @@ export async function installFiles(
     }
 
     try {
-      const content = await fetchFile(manifest.category, manifest.id, basename(file.src))
+      // file.src is relative to the item root (e.g. "files/src/components/Welcome.tsx")
+      // strip the leading "files/" prefix to get the sub-path within the files/ directory
+      const subPath = file.src.replace(/^files\//, '')
+      const content = await fetchFile(manifest.category, manifest.id, subPath)
       mkdirSync(dirname(destPath), { recursive: true })
       writeFileSync(destPath, content, 'utf-8')
       results.push({ path: file.dest, skipped: false })

--- a/packages/cli/src/ui/StackMenu.tsx
+++ b/packages/cli/src/ui/StackMenu.tsx
@@ -7,10 +7,22 @@ interface Props {
   onBack: () => void
 }
 
-const OPTIONS: { label: string; value: Stack }[] = [
-  { label: 'React + Vite', value: 'react-vite' },
-  { label: 'Next.js (create-next-app)', value: 'nextjs' },
-  { label: 'Astro', value: 'astro' },
+const OPTIONS: { label: string; value: Stack; description: string }[] = [
+  {
+    label: 'React + Vite',
+    value: 'react-vite',
+    description: 'Welcome module · components/ · hooks/ · useLocalStorage',
+  },
+  {
+    label: 'Next.js (create-next-app)',
+    value: 'nextjs',
+    description: 'Welcome module · components/ · hooks/ · useLocalStorage',
+  },
+  {
+    label: 'Astro',
+    value: 'astro',
+    description: 'Scaffold base (sin template Sanghel aún)',
+  },
 ]
 
 export function StackMenu({ onSelect, onBack }: Props) {
@@ -30,10 +42,15 @@ export function StackMenu({ onSelect, onBack }: Props) {
       </Text>
       <Text> </Text>
       {OPTIONS.map((opt, i) => (
-        <Text key={opt.value} color={i === cursor ? 'green' : undefined}>
-          {i === cursor ? '▶ ' : '  '}
-          {opt.label}
-        </Text>
+        <Box key={opt.value} flexDirection="column" marginBottom={i === cursor ? 0 : 0}>
+          <Text color={i === cursor ? 'green' : undefined}>
+            {i === cursor ? '▶ ' : '  '}
+            <Text bold={i === cursor}>{opt.label}</Text>
+          </Text>
+          {i === cursor && (
+            <Text dimColor>     {opt.description}</Text>
+          )}
+        </Box>
       ))}
       <Text> </Text>
       <Text dimColor>↑↓ navegar  enter confirmar  esc volver</Text>


### PR DESCRIPTION
## Resumen
FASE 2 completada: al crear un proyecto react-vite o nextjs, se aplica automáticamente un template overlay con Welcome module, estructura de carpetas y hooks básicos con branding Sanghel.

## Tareas Completadas
- [x] Tarea 2.1 + 2.2: Templates react-vite y nextjs en catalog/templates/ (#96, PR #97)
- [x] Tarea 2.3: applyTemplate() integrado post-scaffold (#96, PR #97)
- [x] Tarea 2.4: StackMenu con descripción de cada template (#96, PR #97)

## Nuevo flujo create completo
```
MainMenu → StackMenu → ProjectNameInput → [carga extras] → ExtraSelect
    → scaffold → applyTemplate (Welcome + hooks + structure) → instala extras
```

## Lo que ve el usuario al crear un react-vite
- Welcome screen: "Welcome to Sanghel React + Vite Template"
- Cards con links a docs, playbook, estructura de carpetas, y comando add patterns
- `src/hooks/useLocalStorage.ts` incluido
- Estructura: `src/components/`, `src/hooks/`

## Fixes incluidos
- `installer.ts`: soporte para rutas anidadas en templates (fix crítico)
- `fetcher.ts`: `fetchFile` acepta subPaths con subdirectorios

## Testing
- ✅ Build exitoso (`pnpm build`)
- ✅ Sin errores TypeScript

Closes #95