### PR TITLE
fix: excluir catalog/ del tsconfig raíz

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "packages"]
+  "exclude": ["node_modules", "packages", "catalog"]
 }


### PR DESCRIPTION
Los archivos de templates en `catalog/` usan aliases como `@/` que solo existen en proyectos generados por el CLI, no en el repo. Excluir `catalog/` del `tsconfig.json` raíz evita que el type check del CI falle.