### PR TITLE
fix: excluir catalog/ del tsconfig para pasar CI

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules", "packages"]
+  "exclude": ["node_modules", "packages", "catalog"]
 }


### PR DESCRIPTION
Los templates en `catalog/` usan aliases (`@/`) propios de los proyectos generados. Excluir `catalog/` del tsconfig raíz evita que `tsc --noEmit` falle en CI.