### PR TITLE
feat: sección demo TUI en homepage con TerminalFrame

### DIFF
--- a/demo.tape
+++ b/demo.tape
@@ -1,0 +1,83 @@
+# Sanghel Playbook — TUI demo
+# Install vhs: brew install vhs
+# Run: vhs demo.tape
+
+Output public/demo.gif
+
+Set Shell "bash"
+Set FontSize 15
+Set FontFamily "JetBrains Mono"
+Set Width 900
+Set Height 520
+Set Theme "Catppuccin Mocha"
+Set Padding 20
+Set PlaybackSpeed 1.0
+Set TypingSpeed 80ms
+
+# ── Abrir la terminal ───────────────────────────────────────────────
+Sleep 500ms
+Type "npx sanghel-playbook"
+Sleep 200ms
+Enter
+Sleep 2s
+
+# ── Main Menu: elegir "Crear nuevo proyecto" (primera opción) ───────
+Sleep 500ms
+Enter
+Sleep 800ms
+
+# ── Stack Menu: React + Vite ─────────────────────────────────────────
+Sleep 400ms
+Enter
+Sleep 800ms
+
+# ── ProjectNameInput: escribir nombre ───────────────────────────────
+Sleep 300ms
+Ctrl+a
+Backspace
+Sleep 100ms
+Type "my-awesome-app"
+Sleep 600ms
+Enter
+Sleep 1500ms
+
+# ── Extra Select: github-flow (espacio para seleccionar) ─────────────
+Sleep 400ms
+Space
+Sleep 400ms
+Enter
+Sleep 1500ms
+
+# ── El scaffold corre (stdio:inherit — vhs lo captura) ───────────────
+Sleep 2s
+
+# ── Volver al menú: mostrar flujo "Añadir a proyecto existente" ──────
+Sleep 500ms
+Type "npx sanghel-playbook"
+Sleep 200ms
+Enter
+Sleep 2s
+
+# Main menu: bajar a "Añadir a proyecto existente"
+Down
+Sleep 400ms
+Enter
+Sleep 2000ms
+
+# Navegar por categorías (Rules & Guides)
+Down
+Down
+Down
+Sleep 400ms
+Enter
+Sleep 2000ms
+
+# Seleccionar deploy-guide
+Down
+Sleep 300ms
+Space
+Sleep 400ms
+Enter
+Sleep 2500ms
+
+Sleep 1s

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,22 @@
 import Link from 'next/link'
+import Image from 'next/image'
+import { existsSync } from 'fs'
+import { join } from 'path'
 import { getAllDocs } from '@/lib/docs'
+import { TerminalFrame } from '@/components/TerminalFrame/TerminalFrame'
+
+function hasDemoGif() {
+  return existsSync(join(process.cwd(), 'public', 'demo.gif'))
+}
 
 export default function Home() {
   const docs = getAllDocs()
   const firstDoc = docs[0]
+  const showDemo = hasDemoGif()
 
   return (
-    <div className="flex flex-col items-start max-w-2xl mx-auto px-6 py-16">
+    <div className="flex flex-col items-start max-w-3xl mx-auto px-6 py-16">
+      {/* Hero */}
       <div className="mb-2 text-xs font-semibold uppercase tracking-widest text-zinc-400 dark:text-zinc-500">
         Personal Playbook
       </div>
@@ -20,7 +30,7 @@ export default function Home() {
         A living reference built in the open.
       </p>
 
-      <div className="flex gap-3">
+      <div className="flex gap-3 mb-20">
         {firstDoc ? (
           <Link
             href={`/docs/${firstDoc.slug.join('/')}`}
@@ -43,6 +53,73 @@ export default function Home() {
         >
           GitHub
         </a>
+      </div>
+
+      {/* Demo section */}
+      <div className="w-full">
+        <div className="mb-2 text-xs font-semibold uppercase tracking-widest text-zinc-400 dark:text-zinc-500">
+          CLI / TUI
+        </div>
+        <h2 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50 mb-3">
+          Instala patrones desde la terminal
+        </h2>
+        <p className="text-base text-zinc-500 dark:text-zinc-400 mb-8">
+          Crea proyectos con tu stack favorito, aplica templates con branding propio
+          y añade patrones al instante — sin copiar código.
+        </p>
+
+        <TerminalFrame>
+          {showDemo ? (
+            <Image
+              src="/demo.gif"
+              alt="Sanghel Playbook TUI demo"
+              width={780}
+              height={440}
+              unoptimized
+              priority
+            />
+          ) : (
+            <DemoPlaceholder />
+          )}
+        </TerminalFrame>
+
+        <p className="mt-4 text-sm text-zinc-400 dark:text-zinc-500">
+          <code className="font-mono text-xs bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded">
+            npx sanghel-playbook
+          </code>
+          {' '}— funciona con npm, pnpm y yarn.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function DemoPlaceholder() {
+  return (
+    <div className="flex flex-col gap-3 p-6 min-h-[260px] justify-center font-mono text-sm">
+      <div className="flex gap-2 items-center">
+        <span className="text-zinc-600">$</span>
+        <span className="text-zinc-300">npx sanghel-playbook</span>
+      </div>
+      <div className="pl-4 flex flex-col gap-1 text-zinc-400">
+        <div>
+          <span className="text-green-400">▶</span>
+          {' '}Crear nuevo proyecto
+        </div>
+        <div className="text-zinc-600">  Añadir a proyecto existente</div>
+      </div>
+      <div className="pl-4 flex flex-col gap-1 text-zinc-400 mt-1">
+        <div className="text-zinc-500 text-xs">Selecciona el stack base:</div>
+        <div>
+          <span className="text-green-400">▶</span>
+          {' '}React + Vite
+          <span className="text-zinc-600 text-xs ml-2">Welcome module · components/ · hooks/</span>
+        </div>
+        <div className="text-zinc-600">  Next.js (create-next-app)</div>
+        <div className="text-zinc-600">  Astro</div>
+      </div>
+      <div className="mt-3 text-zinc-600 text-xs italic">
+        — Graba el GIF con: vhs demo.tape
       </div>
     </div>
   )

--- a/src/components/TerminalFrame/TerminalFrame.module.css
+++ b/src/components/TerminalFrame/TerminalFrame.module.css
@@ -1,0 +1,64 @@
+.window {
+  width: 100%;
+  max-width: 780px;
+  border-radius: 10px;
+  border: 1px solid #27272a;
+  background: #09090b;
+  overflow: hidden;
+  box-shadow:
+    0 0 0 1px #18181b,
+    0 20px 60px rgba(0, 0, 0, 0.5),
+    0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.titlebar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.625rem 1rem;
+  background: #18181b;
+  border-bottom: 1px solid #27272a;
+  position: relative;
+}
+
+.dots {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.dotRed,
+.dotYellow,
+.dotGreen {
+  display: block;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.dotRed    { background: #ff5f57; }
+.dotYellow { background: #ffbd2e; }
+.dotGreen  { background: #28c840; }
+
+.title {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.75rem;
+  color: #52525b;
+  font-family: 'Geist Mono', 'JetBrains Mono', monospace;
+  letter-spacing: 0.02em;
+  pointer-events: none;
+}
+
+.body {
+  padding: 0;
+  line-height: 0;
+}
+
+.body img {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 0 0 9px 9px;
+}

--- a/src/components/TerminalFrame/TerminalFrame.tsx
+++ b/src/components/TerminalFrame/TerminalFrame.tsx
@@ -1,0 +1,22 @@
+import styles from './TerminalFrame.module.css'
+
+interface Props {
+  children: React.ReactNode
+  title?: string
+}
+
+export function TerminalFrame({ children, title = 'sanghel-playbook' }: Props) {
+  return (
+    <div className={styles.window}>
+      <div className={styles.titlebar}>
+        <div className={styles.dots}>
+          <span className={styles.dotRed} />
+          <span className={styles.dotYellow} />
+          <span className={styles.dotGreen} />
+        </div>
+        <span className={styles.title}>{title}</span>
+      </div>
+      <div className={styles.body}>{children}</div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Cambios

### demo.tape
Script vhs para grabar el flujo completo del TUI — cubre: main menu → crear proyecto → nombre → seleccionar extras → scaffold. Para generar el GIF: `vhs demo.tape` (requiere `brew install vhs`). Output: `public/demo.gif`.

### TerminalFrame
- `src/components/TerminalFrame/TerminalFrame.tsx`
- `src/components/TerminalFrame/TerminalFrame.module.css`
- Ventana macOS con barra de colores (●●●), título centrado, fondo `#09090b`, box-shadow de profundidad

### Homepage (page.tsx)
- Sección demo bajo el hero con título "Instala patrones desde la terminal"
- Renderiza el GIF en `TerminalFrame` si existe `public/demo.gif`
- Si no existe el GIF (antes de grabarlo), muestra un placeholder ASCII del TUI con instrucciones
- `max-w-3xl` en vez de `max-w-2xl` para darle más espacio a la demo

## Testing
- ✅ `npx tsc --noEmit` — sin errores
- ✅ `pnpm lint` — limpio
- ✅ `pnpm build` — OK
- ✅ Placeholder visible (sin demo.gif) — textura de terminal

Closes #106
Closes #107
Closes #108
Related to #105