### PR TITLE
feat: TUI flujo con package manager e integraciones à la carte

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,12 +1,13 @@
 import { fetchManifest } from '../lib/fetcher.js'
 import { installFiles } from '../lib/installer.js'
 import { scaffold } from '../lib/scaffolder.js'
+import type { PackageManager } from '../lib/package-manager.js'
 import type { InstallStep } from '../types.js'
 import type { Stack } from '../lib/scaffolder.js'
 
 export type { Stack }
 
-export function createProject(stack: Stack, projectName: string): boolean {
+export function createProject(stack: Stack, projectName: string, pkgManager?: PackageManager): boolean {
   return scaffold(stack, projectName)
 }
 
@@ -18,6 +19,7 @@ const TEMPLATE_MAP: Partial<Record<Stack, string>> = {
 export async function applyTemplate(
   stack: Stack,
   projectCwd: string,
+  pkgManager: PackageManager | undefined,
   onStep: (step: InstallStep) => void
 ): Promise<void> {
   const templateId = TEMPLATE_MAP[stack]

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -8,6 +8,7 @@ import type { Stack } from '../lib/scaffolder.js'
 export type { Stack }
 
 export function createProject(stack: Stack, projectName: string, pkgManager?: PackageManager): boolean {
+  // TODO Phase 2: pass pkgManager to scaffold so initial install uses the selected PM
   return scaffold(stack, projectName)
 }
 
@@ -33,6 +34,7 @@ export async function applyTemplate(
     return
   }
 
+  // TODO Phase 2: use pkgManager for dep installation
   const results = await installFiles(manifest, projectCwd)
   for (const result of results) {
     onStep({

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -3,21 +3,25 @@ import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { render, Box, Text, useApp } from 'ink'
 import { MainMenu } from './ui/MainMenu.js'
 import { StackMenu } from './ui/StackMenu.js'
+import { PackageManagerMenu } from './ui/PackageManagerMenu.js'
 import { ProjectNameInput } from './ui/ProjectNameInput.js'
 import { CategoryMenu } from './ui/CategoryMenu.js'
 import { ItemSelect } from './ui/ItemSelect.js'
+import { IntegrationsSelect } from './ui/IntegrationsSelect.js'
 import { InstallProgress } from './ui/InstallProgress.js'
 import { loadCatalog, loadCategoryItems, loadItemsByStack, runInstall } from './commands/add.js'
 import { createProject, applyTemplate } from './commands/create.js'
 import type { CategoryRef, ManifestItem, InstallStep } from './types.js'
+import type { PackageManager } from './lib/package-manager.js'
 import type { Stack } from './commands/create.js'
 
 type Screen =
   | { id: 'main-menu' }
   | { id: 'stack-menu' }
-  | { id: 'project-name'; stack: Stack }
+  | { id: 'pkg-manager'; stack: Stack }
+  | { id: 'project-name'; stack: Stack; pkgManager: PackageManager }
   | { id: 'loading'; message: string }
-  | { id: 'extra-select'; stack: Stack; projectName: string; items: ManifestItem[] }
+  | { id: 'integrations-select'; stack: Stack; pkgManager: PackageManager; projectName: string; items: ManifestItem[] }
   | { id: 'category-menu'; categories: CategoryRef[] }
   | { id: 'item-select'; category: CategoryRef; items: ManifestItem[] }
   | { id: 'install-progress'; steps: InstallStep[]; done: boolean; docsUrl: string | null }
@@ -41,11 +45,15 @@ function App() {
   )
 
   const handleStackSelect = useCallback((stack: Stack) => {
-    setScreen({ id: 'project-name', stack })
+    setScreen({ id: 'pkg-manager', stack })
   }, [])
 
-  const handleProjectNameConfirm = useCallback((stack: Stack, name: string) => {
-    setScreen({ id: 'loading', message: 'Cargando extras del catálogo...' })
+  const handlePkgManagerSelect = useCallback((stack: Stack, pkgManager: PackageManager) => {
+    setScreen({ id: 'project-name', stack, pkgManager })
+  }, [])
+
+  const handleProjectNameConfirm = useCallback((stack: Stack, pkgManager: PackageManager, name: string) => {
+    setScreen({ id: 'loading', message: 'Cargando integraciones del catálogo...' })
     loadItemsByStack(stack)
       .then(async (items) => {
         // Fall back to all catalog items if none match this stack
@@ -54,24 +62,21 @@ function App() {
           const all = await Promise.all(categories.map((c) => loadCategoryItems(c.id).catch(() => [] as ManifestItem[])))
           items = all.flat()
         }
-        if (items.length === 0) {
-          handleCreateWithExtras(stack, name, [])
-        } else {
-          setScreen({ id: 'extra-select', stack, projectName: name, items })
-        }
+        setScreen({ id: 'integrations-select', stack, pkgManager, projectName: name, items })
       })
       .catch(() => {
-        handleCreateWithExtras(stack, name, [])
+        // On error, skip integrations and create directly
+        setScreen({ id: 'integrations-select', stack, pkgManager, projectName: name, items: [] })
       })
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   // spawnSync with stdio:'inherit' conflicts with Ink's TTY control.
   // Exit Ink first, defer createProject to let Ink finish teardown, then scaffold + extras.
-  const handleCreateWithExtras = useCallback((stack: Stack, projectName: string, extras: ManifestItem[]) => {
+  const handleCreateWithExtras = useCallback((stack: Stack, projectName: string, extras: ManifestItem[], pkgManager: PackageManager) => {
     exit()
     setImmediate(() => {
       void (async () => {
-        const ok = createProject(stack, projectName)
+        const ok = createProject(stack, projectName, pkgManager)
         if (!ok) {
           console.error('\n✗ Error al crear el proyecto.')
           process.exit(1)
@@ -86,17 +91,17 @@ function App() {
 
         console.log('\nAplicando template Sanghel...')
         try {
-          await applyTemplate(stack, projectCwd, logStep)
+          await applyTemplate(stack, projectCwd, pkgManager, logStep)
         } catch (err) {
           console.error(`  ✗ Error aplicando template: ${String(err)}`)
         }
 
         if (extras.length > 0) {
-          console.log('\nInstalando extras...')
+          console.log('\nInstalando integraciones...')
           try {
             await runInstall(extras, projectCwd, logStep)
           } catch (err) {
-            console.error(`  ✗ Error instalando extras: ${String(err)}`)
+            console.error(`  ✗ Error instalando integraciones: ${String(err)}`)
           }
         }
 
@@ -169,12 +174,23 @@ function App() {
     )
   }
 
+  if (screen.id === 'pkg-manager') {
+    const { stack } = screen
+    return (
+      <PackageManagerMenu
+        onSelect={(pm) => handlePkgManagerSelect(stack, pm)}
+        onBack={() => setScreen({ id: 'stack-menu' })}
+      />
+    )
+  }
+
   if (screen.id === 'project-name') {
+    const { stack, pkgManager } = screen
     return (
       <ProjectNameInput
-        stack={screen.stack}
-        onConfirm={(name) => handleProjectNameConfirm(screen.stack, name)}
-        onBack={() => setScreen({ id: 'stack-menu' })}
+        stack={stack}
+        onConfirm={(name) => handleProjectNameConfirm(stack, pkgManager, name)}
+        onBack={() => setScreen({ id: 'pkg-manager', stack })}
       />
     )
   }
@@ -187,15 +203,14 @@ function App() {
     )
   }
 
-  if (screen.id === 'extra-select') {
-    const { stack, projectName, items } = screen
+  if (screen.id === 'integrations-select') {
+    const { stack, pkgManager, projectName, items } = screen
     return (
-      <ItemSelect
+      <IntegrationsSelect
         items={items}
-        categoryLabel={`Extras para ${stack} — "${projectName}"`}
-        onInstall={(selected) => handleCreateWithExtras(stack, projectName, selected)}
-        onBack={() => setScreen({ id: 'project-name', stack })}
-        allowEmpty
+        framework={stack}
+        onConfirm={(selected) => handleCreateWithExtras(stack, projectName, selected, pkgManager)}
+        onBack={() => setScreen({ id: 'project-name', stack, pkgManager })}
       />
     )
   }

--- a/packages/cli/src/index.tsx
+++ b/packages/cli/src/index.tsx
@@ -11,8 +11,7 @@ import { IntegrationsSelect } from './ui/IntegrationsSelect.js'
 import { InstallProgress } from './ui/InstallProgress.js'
 import { loadCatalog, loadCategoryItems, loadItemsByStack, runInstall } from './commands/add.js'
 import { createProject, applyTemplate } from './commands/create.js'
-import type { CategoryRef, ManifestItem, InstallStep } from './types.js'
-import type { PackageManager } from './lib/package-manager.js'
+import type { CategoryRef, ManifestItem, InstallStep, PackageManager } from './types.js'
 import type { Stack } from './commands/create.js'
 
 type Screen =

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,3 +1,5 @@
+export type { PackageManager } from './lib/package-manager.js'
+
 export interface CatalogIndex {
   categories: CategoryRef[]
 }
@@ -19,6 +21,14 @@ export interface DepsMap {
   devDependencies: string[]
 }
 
+export type PatchOperation = 'prepend' | 'append' | 'append-import'
+
+export interface ManifestPatch {
+  file: string
+  operation: PatchOperation
+  content: string
+}
+
 export interface ManifestItem {
   id: string
   name: string
@@ -28,7 +38,11 @@ export interface ManifestItem {
   deps: DepsMap
   files: FileEntry[]
   docsUrl: string
+  patches?: ManifestPatch[]
 }
+
+// Semantic alias — same shape as ManifestItem, used in the integrations select flow
+export type Integration = ManifestItem
 
 export interface FileEntry {
   src: string

--- a/packages/cli/src/ui/IntegrationsSelect.tsx
+++ b/packages/cli/src/ui/IntegrationsSelect.tsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react'
 import { Box, Text, useInput } from 'ink'
-import type { ManifestItem } from '../types.js'
+import type { Integration } from '../types.js'
 
 interface Props {
-  items: ManifestItem[]
+  items: Integration[]
   framework: string
-  onConfirm: (selected: ManifestItem[]) => void
+  onConfirm: (selected: Integration[]) => void
   onBack: () => void
 }
 
@@ -16,6 +16,7 @@ export function IntegrationsSelect({ items, framework, onConfirm, onBack }: Prop
   useInput((input, key) => {
     if (items.length === 0) {
       if (key.escape) onBack()
+      if (key.return) onConfirm([])
       return
     }
     if (key.upArrow) setCursor((c) => Math.max(0, c - 1))
@@ -59,7 +60,11 @@ export function IntegrationsSelect({ items, framework, onConfirm, onBack }: Prop
         ))
       )}
       <Text> </Text>
-      <Text dimColor>↑↓ navegar  espacio seleccionar  enter confirmar  esc volver</Text>
+      {items.length === 0 ? (
+        <Text dimColor>enter continuar  esc volver</Text>
+      ) : (
+        <Text dimColor>↑↓ navegar  espacio seleccionar  enter confirmar  esc volver</Text>
+      )}
       {selected.size > 0 && (
         <Text color="yellow">{selected.size} integración(es) seleccionada(s)</Text>
       )}

--- a/packages/cli/src/ui/IntegrationsSelect.tsx
+++ b/packages/cli/src/ui/IntegrationsSelect.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import type { ManifestItem } from '../types.js'
+
+interface Props {
+  items: ManifestItem[]
+  framework: string
+  onConfirm: (selected: ManifestItem[]) => void
+  onBack: () => void
+}
+
+export function IntegrationsSelect({ items, framework, onConfirm, onBack }: Props) {
+  const [cursor, setCursor] = useState(0)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+
+  useInput((input, key) => {
+    if (items.length === 0) {
+      if (key.escape) onBack()
+      return
+    }
+    if (key.upArrow) setCursor((c) => Math.max(0, c - 1))
+    if (key.downArrow) setCursor((c) => Math.min(items.length - 1, c + 1))
+    if (input === ' ') {
+      setSelected((s) => {
+        const next = new Set(s)
+        const id = items[cursor].id
+        if (next.has(id)) next.delete(id)
+        else next.add(id)
+        return next
+      })
+    }
+    if (key.return) {
+      const toConfirm = items.filter((item) => selected.has(item.id))
+      onConfirm(toConfirm)
+    }
+    if (key.escape) onBack()
+  })
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        Integraciones para {framework}
+      </Text>
+      <Text> </Text>
+      {items.length === 0 ? (
+        <Text dimColor>No hay integraciones disponibles para este stack</Text>
+      ) : (
+        items.map((item, i) => (
+          <Box key={item.id} flexDirection="column">
+            <Text color={i === cursor ? 'green' : undefined}>
+              {i === cursor ? '▶ ' : '  '}
+              {selected.has(item.id) ? '[✓] ' : '[ ] '}
+              <Text bold={i === cursor}>{item.name}</Text>
+            </Text>
+            {i === cursor && (
+              <Text dimColor>     {item.description}</Text>
+            )}
+          </Box>
+        ))
+      )}
+      <Text> </Text>
+      <Text dimColor>↑↓ navegar  espacio seleccionar  enter confirmar  esc volver</Text>
+      {selected.size > 0 && (
+        <Text color="yellow">{selected.size} integración(es) seleccionada(s)</Text>
+      )}
+    </Box>
+  )
+}

--- a/packages/cli/src/ui/PackageManagerMenu.tsx
+++ b/packages/cli/src/ui/PackageManagerMenu.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react'
+import { Box, Text, useInput } from 'ink'
+import type { PackageManager } from '../lib/package-manager.js'
+
+interface Props {
+  onSelect: (pm: PackageManager) => void
+  onBack: () => void
+}
+
+const OPTIONS: { label: string; value: PackageManager; description: string }[] = [
+  {
+    label: 'pnpm',
+    value: 'pnpm',
+    description: 'Recomendado — workspace-friendly y rápido',
+  },
+  {
+    label: 'npm',
+    value: 'npm',
+    description: 'El gestor por defecto de Node.js',
+  },
+  {
+    label: 'yarn',
+    value: 'yarn',
+    description: 'Alternativa popular con workspaces',
+  },
+]
+
+export function PackageManagerMenu({ onSelect, onBack }: Props) {
+  const [cursor, setCursor] = useState(0)
+
+  useInput((_, key) => {
+    if (key.upArrow) setCursor((c) => Math.max(0, c - 1))
+    if (key.downArrow) setCursor((c) => Math.min(OPTIONS.length - 1, c + 1))
+    if (key.return) onSelect(OPTIONS[cursor].value)
+    if (key.escape) onBack()
+  })
+
+  return (
+    <Box flexDirection="column" padding={1}>
+      <Text bold color="cyan">
+        Nuevo proyecto — elige el gestor de paquetes
+      </Text>
+      <Text> </Text>
+      {OPTIONS.map((opt, i) => (
+        <Box key={opt.value} flexDirection="column">
+          <Text color={i === cursor ? 'green' : undefined}>
+            {i === cursor ? '▶ ' : '  '}
+            <Text bold={i === cursor}>{opt.label}</Text>
+          </Text>
+          {i === cursor && (
+            <Text dimColor>     {opt.description}</Text>
+          )}
+        </Box>
+      ))}
+      <Text> </Text>
+      <Text dimColor>↑↓ navegar  enter confirmar  esc volver</Text>
+    </Box>
+  )
+}


### PR DESCRIPTION
## Summary

- Nuevo paso `PackageManagerMenu` (pnpm / npm / yarn) entre stack-menu y project-name
- Nuevo paso `IntegrationsSelect` (multiselect à la carte) que reemplaza `extra-select`
- Screen union actualizado: añade `pkg-manager` e `integrations-select`, elimina `extra-select`
- `create.ts` acepta `pkgManager` param en `createProject` y `applyTemplate`
- `types.ts`: añade `Integration` alias, `ManifestPatch` interface, campo `patches?` en `ManifestItem`, re-exporta `PackageManager`

## Nuevo flujo create

```
main-menu → stack-menu → PackageManagerMenu → project-name → IntegrationsSelect → handleCreateWithExtras
```

## Test plan

- [ ] `pnpm build` en `packages/cli` compila sin errores (verificado ✓)
- [ ] `node dist/index.js` → "Crear nuevo proyecto" muestra stack → package manager → nombre → integraciones
- [ ] Esc en PackageManagerMenu vuelve a stack-menu
- [ ] Esc en IntegrationsSelect vuelve a project-name
- [ ] Enter en IntegrationsSelect sin seleccionar nada crea el proyecto sin integraciones
- [ ] Flujo "Añadir a proyecto existente" no se ve afectado

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)