### PR TITLE
feat: catalog módulos de integración Next.js

### DIFF
--- a/catalog/nextjs/auth/files/src/app/api/auth/[...nextauth]/route.ts
+++ b/catalog/nextjs/auth/files/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,2 @@
+import { handlers } from '@/auth'
+export const { GET, POST } = handlers

--- a/catalog/nextjs/auth/files/src/auth.ts
+++ b/catalog/nextjs/auth/files/src/auth.ts
@@ -1,0 +1,20 @@
+import NextAuth from 'next-auth'
+import Credentials from 'next-auth/providers/credentials'
+
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  providers: [
+    Credentials({
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        // TODO: replace with real DB lookup
+        if (credentials.email === 'user@example.com' && credentials.password === 'password') {
+          return { id: '1', email: credentials.email as string, name: 'Demo User' }
+        }
+        return null
+      },
+    }),
+  ],
+})

--- a/catalog/nextjs/auth/files/src/components/SessionProvider.tsx
+++ b/catalog/nextjs/auth/files/src/components/SessionProvider.tsx
@@ -1,0 +1,6 @@
+'use client'
+import { SessionProvider as NextAuthSessionProvider } from 'next-auth/react'
+
+export function SessionProvider({ children }: { children: React.ReactNode }) {
+  return <NextAuthSessionProvider>{children}</NextAuthSessionProvider>
+}

--- a/catalog/nextjs/auth/manifest.json
+++ b/catalog/nextjs/auth/manifest.json
@@ -1,0 +1,30 @@
+{
+  "id": "auth",
+  "name": "NextAuth v5",
+  "description": "Autenticación con NextAuth v5 — auth.ts, SessionProvider y ruta API configurados con Credentials provider",
+  "category": "nextjs",
+  "tags": ["nextjs", "auth", "authentication"],
+  "deps": {
+    "dependencies": ["next-auth@beta"],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/src/auth.ts", "dest": "src/auth.ts" },
+    { "src": "files/src/app/api/auth/[...nextauth]/route.ts", "dest": "src/app/api/auth/[...nextauth]/route.ts" },
+    { "src": "files/src/components/SessionProvider.tsx", "dest": "src/components/SessionProvider.tsx" }
+  ],
+  "patches": [
+    {
+      "file": "src/app/layout.tsx",
+      "operation": "append-import",
+      "content": "import { SessionProvider } from '@/components/SessionProvider'"
+    },
+    {
+      "file": "src/app/layout.tsx",
+      "operation": "replace",
+      "marker": "{children}",
+      "content": "<SessionProvider>{children}</SessionProvider>"
+    }
+  ],
+  "docsUrl": "https://authjs.dev/getting-started/installation"
+}

--- a/catalog/nextjs/currency/files/src/utils/currency.ts
+++ b/catalog/nextjs/currency/files/src/utils/currency.ts
@@ -28,6 +28,8 @@ export function formatAmount(
   }).format(amount)
 }
 
+// Note: for financial calculations requiring exact precision, use a library like decimal.js
+// This utility is suitable for display/input parsing only
 export function parseCurrency(value: string): number {
   const cleaned = value.replace(/[^0-9.,]/g, '').replace(',', '.')
   return parseFloat(cleaned) || 0

--- a/catalog/nextjs/currency/files/src/utils/currency.ts
+++ b/catalog/nextjs/currency/files/src/utils/currency.ts
@@ -1,0 +1,42 @@
+type CurrencyOptions = {
+  currency?: string
+  locale?: string
+  minimumFractionDigits?: number
+  maximumFractionDigits?: number
+}
+
+export function formatCurrency(
+  amount: number,
+  { currency = 'USD', locale = 'es-CO', minimumFractionDigits = 2, maximumFractionDigits = 2 }: CurrencyOptions = {}
+): string {
+  return new Intl.NumberFormat(locale, {
+    style: 'currency',
+    currency,
+    minimumFractionDigits,
+    maximumFractionDigits,
+  }).format(amount)
+}
+
+export function formatAmount(
+  amount: number,
+  { locale = 'es-CO', minimumFractionDigits = 2, maximumFractionDigits = 2 }: Omit<CurrencyOptions, 'currency'> = {}
+): string {
+  return new Intl.NumberFormat(locale, {
+    style: 'decimal',
+    minimumFractionDigits,
+    maximumFractionDigits,
+  }).format(amount)
+}
+
+export function parseCurrency(value: string): number {
+  const cleaned = value.replace(/[^0-9.,]/g, '').replace(',', '.')
+  return parseFloat(cleaned) || 0
+}
+
+export function centsToDollars(cents: number): number {
+  return cents / 100
+}
+
+export function dollarsToCents(dollars: number): number {
+  return Math.round(dollars * 100)
+}

--- a/catalog/nextjs/currency/manifest.json
+++ b/catalog/nextjs/currency/manifest.json
@@ -1,0 +1,16 @@
+{
+  "id": "currency",
+  "name": "Currency Helpers",
+  "description": "Funciones de formato para valores monetarios usando Intl.NumberFormat — sin dependencias externas",
+  "category": "nextjs",
+  "tags": ["nextjs", "utils", "currency", "formatting"],
+  "deps": {
+    "dependencies": [],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/src/utils/currency.ts", "dest": "src/utils/currency.ts" }
+  ],
+  "patches": [],
+  "docsUrl": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat"
+}

--- a/catalog/nextjs/dayjs/files/src/utils/date.ts
+++ b/catalog/nextjs/dayjs/files/src/utils/date.ts
@@ -1,0 +1,32 @@
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import localizedFormat from 'dayjs/plugin/localizedFormat'
+import 'dayjs/locale/es'
+
+dayjs.extend(relativeTime)
+dayjs.extend(localizedFormat)
+dayjs.locale('es')
+
+export function formatDate(date: Date | string | number, format = 'DD/MM/YYYY'): string {
+  return dayjs(date).format(format)
+}
+
+export function formatDateTime(date: Date | string | number): string {
+  return dayjs(date).format('DD/MM/YYYY HH:mm')
+}
+
+export function formatRelative(date: Date | string | number): string {
+  return dayjs(date).fromNow()
+}
+
+export function parseDate(dateString: string, format = 'DD/MM/YYYY'): Date {
+  return dayjs(dateString, format).toDate()
+}
+
+export function isValidDate(date: unknown): boolean {
+  return dayjs(date as string).isValid()
+}
+
+export function addDays(date: Date | string, days: number): Date {
+  return dayjs(date).add(days, 'day').toDate()
+}

--- a/catalog/nextjs/dayjs/manifest.json
+++ b/catalog/nextjs/dayjs/manifest.json
@@ -1,0 +1,16 @@
+{
+  "id": "dayjs",
+  "name": "Day.js",
+  "description": "Day.js con helpers para formatear fechas, calcular tiempo relativo y parsear strings",
+  "category": "nextjs",
+  "tags": ["nextjs", "dates", "dayjs"],
+  "deps": {
+    "dependencies": ["dayjs"],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/src/utils/date.ts", "dest": "src/utils/date.ts" }
+  ],
+  "patches": [],
+  "docsUrl": "https://day.js.org/docs/en/installation/installation"
+}

--- a/catalog/nextjs/i18n/files/src/i18n/config.ts
+++ b/catalog/nextjs/i18n/files/src/i18n/config.ts
@@ -1,3 +1,6 @@
+// Note: this i18next setup is for Client Components only.
+// For Server Components (RSC) in Next.js App Router, import translations directly
+// or use a server-compatible i18n library like next-intl.
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'

--- a/catalog/nextjs/i18n/files/src/i18n/config.ts
+++ b/catalog/nextjs/i18n/files/src/i18n/config.ts
@@ -1,0 +1,19 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
+import es from './locales/es.json'
+import en from './locales/en.json'
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    fallbackLng: 'es',
+    resources: {
+      es: { translation: es },
+      en: { translation: en },
+    },
+    interpolation: { escapeValue: false },
+  })
+
+export default i18n

--- a/catalog/nextjs/i18n/files/src/i18n/locales/en.json
+++ b/catalog/nextjs/i18n/files/src/i18n/locales/en.json
@@ -1,0 +1,7 @@
+{
+  "welcome": "Welcome",
+  "hello": "Hello, {{name}}",
+  "save": "Save",
+  "cancel": "Cancel",
+  "loading": "Loading..."
+}

--- a/catalog/nextjs/i18n/files/src/i18n/locales/es.json
+++ b/catalog/nextjs/i18n/files/src/i18n/locales/es.json
@@ -1,0 +1,7 @@
+{
+  "welcome": "Bienvenido",
+  "hello": "Hola, {{name}}",
+  "save": "Guardar",
+  "cancel": "Cancelar",
+  "loading": "Cargando..."
+}

--- a/catalog/nextjs/i18n/manifest.json
+++ b/catalog/nextjs/i18n/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "i18n",
+  "name": "i18next + react-i18next",
+  "description": "Internacionalización con i18next y react-i18next — configuración cliente, archivos de traducción ES/EN y hook useTranslation",
+  "category": "nextjs",
+  "tags": ["nextjs", "i18n", "internationalization", "i18next"],
+  "deps": {
+    "dependencies": ["i18next", "react-i18next", "i18next-browser-languagedetector"],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/src/i18n/config.ts", "dest": "src/i18n/config.ts" },
+    { "src": "files/src/i18n/locales/es.json", "dest": "src/i18n/locales/es.json" },
+    { "src": "files/src/i18n/locales/en.json", "dest": "src/i18n/locales/en.json" }
+  ],
+  "patches": [],
+  "docsUrl": "https://react.i18next.com/latest/using-with-hooks"
+}

--- a/catalog/nextjs/index.json
+++ b/catalog/nextjs/index.json
@@ -1,5 +1,5 @@
 {
   "category": "nextjs",
   "label": "Next.js",
-  "items": []
+  "items": ["auth", "react-query", "react-hook-form", "ui-antd", "ui-mui", "ui-radix", "i18n", "zustand", "redux", "dayjs", "currency"]
 }

--- a/catalog/nextjs/react-hook-form/files/src/components/FormBuilder/FormBuilder.tsx
+++ b/catalog/nextjs/react-hook-form/files/src/components/FormBuilder/FormBuilder.tsx
@@ -1,0 +1,55 @@
+'use client'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+
+type FieldDef = {
+  name: string
+  label: string
+  type?: 'text' | 'email' | 'password' | 'number'
+  placeholder?: string
+}
+
+type FormBuilderProps<T extends z.ZodType> = {
+  schema: T
+  fields: FieldDef[]
+  onSubmit: (data: z.infer<T>) => void | Promise<void>
+  submitLabel?: string
+}
+
+export function FormBuilder<T extends z.ZodType>({
+  schema,
+  fields,
+  onSubmit,
+  submitLabel = 'Enviar',
+}: FormBuilderProps<T>) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<z.infer<T>>({ resolver: zodResolver(schema) })
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      {fields.map((field) => (
+        <div key={field.name}>
+          <label htmlFor={field.name}>{field.label}</label>
+          <input
+            id={field.name}
+            type={field.type ?? 'text'}
+            placeholder={field.placeholder}
+            {...register(field.name as never)}
+          />
+          {errors[field.name] && (
+            <span style={{ color: 'red', fontSize: '0.8rem' }}>
+              {(errors[field.name] as { message?: string })?.message}
+            </span>
+          )}
+        </div>
+      ))}
+      <button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? 'Enviando...' : submitLabel}
+      </button>
+    </form>
+  )
+}

--- a/catalog/nextjs/react-hook-form/files/src/components/FormBuilder/index.ts
+++ b/catalog/nextjs/react-hook-form/files/src/components/FormBuilder/index.ts
@@ -1,0 +1,1 @@
+export { FormBuilder } from './FormBuilder'

--- a/catalog/nextjs/react-hook-form/manifest.json
+++ b/catalog/nextjs/react-hook-form/manifest.json
@@ -1,0 +1,17 @@
+{
+  "id": "react-hook-form",
+  "name": "React Hook Form + Zod",
+  "description": "React Hook Form con validación Zod y FormBuilder genérico listo para usar",
+  "category": "nextjs",
+  "tags": ["nextjs", "forms", "react-hook-form", "zod"],
+  "deps": {
+    "dependencies": ["react-hook-form", "zod", "@hookform/resolvers"],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/src/components/FormBuilder/FormBuilder.tsx", "dest": "src/components/FormBuilder/FormBuilder.tsx" },
+    { "src": "files/src/components/FormBuilder/index.ts", "dest": "src/components/FormBuilder/index.ts" }
+  ],
+  "patches": [],
+  "docsUrl": "https://react-hook-form.com/get-started"
+}

--- a/catalog/nextjs/react-query/files/src/hooks/useQueryHooks.ts
+++ b/catalog/nextjs/react-query/files/src/hooks/useQueryHooks.ts
@@ -1,0 +1,19 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+
+// Example: replace T and the fetch logic with your real API
+export function useData<T>(key: string[], fetcher: () => Promise<T>) {
+  return useQuery({ queryKey: key, queryFn: fetcher })
+}
+
+export function useMutate<TData, TVariables>(
+  mutationFn: (variables: TVariables) => Promise<TData>,
+  invalidateKeys?: string[][]
+) {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn,
+    onSuccess: () => {
+      invalidateKeys?.forEach((key) => queryClient.invalidateQueries({ queryKey: key }))
+    },
+  })
+}

--- a/catalog/nextjs/react-query/files/src/lib/queryClient.ts
+++ b/catalog/nextjs/react-query/files/src/lib/queryClient.ts
@@ -1,0 +1,11 @@
+import { QueryClient } from '@tanstack/react-query'
+
+export function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+      },
+    },
+  })
+}

--- a/catalog/nextjs/react-query/files/src/providers/QueryProvider.tsx
+++ b/catalog/nextjs/react-query/files/src/providers/QueryProvider.tsx
@@ -1,0 +1,15 @@
+'use client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import { useState } from 'react'
+import { makeQueryClient } from '@/lib/queryClient'
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => makeQueryClient())
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  )
+}

--- a/catalog/nextjs/react-query/manifest.json
+++ b/catalog/nextjs/react-query/manifest.json
@@ -1,0 +1,30 @@
+{
+  "id": "react-query",
+  "name": "React Query (TanStack Query v5)",
+  "description": "TanStack Query v5 con QueryClient global, hooks de ejemplo useQuery/useMutation y QueryProvider listo para App Router",
+  "category": "nextjs",
+  "tags": ["nextjs", "react-query", "data-fetching", "tanstack"],
+  "deps": {
+    "dependencies": ["@tanstack/react-query"],
+    "devDependencies": ["@tanstack/react-query-devtools"]
+  },
+  "files": [
+    { "src": "files/src/lib/queryClient.ts", "dest": "src/lib/queryClient.ts" },
+    { "src": "files/src/providers/QueryProvider.tsx", "dest": "src/providers/QueryProvider.tsx" },
+    { "src": "files/src/hooks/useQueryHooks.ts", "dest": "src/hooks/useQueryHooks.ts" }
+  ],
+  "patches": [
+    {
+      "file": "src/app/layout.tsx",
+      "operation": "append-import",
+      "content": "import { QueryProvider } from '@/providers/QueryProvider'"
+    },
+    {
+      "file": "src/app/layout.tsx",
+      "operation": "replace",
+      "marker": "{children}",
+      "content": "<QueryProvider>{children}</QueryProvider>"
+    }
+  ],
+  "docsUrl": "https://tanstack.com/query/latest/docs/framework/react/overview"
+}

--- a/catalog/nextjs/redux/files/src/providers/ReduxProvider.tsx
+++ b/catalog/nextjs/redux/files/src/providers/ReduxProvider.tsx
@@ -1,0 +1,7 @@
+'use client'
+import { Provider } from 'react-redux'
+import { store } from '@/store/store'
+
+export function ReduxProvider({ children }: { children: React.ReactNode }) {
+  return <Provider store={store}>{children}</Provider>
+}

--- a/catalog/nextjs/redux/files/src/store/slices/appSlice.ts
+++ b/catalog/nextjs/redux/files/src/store/slices/appSlice.ts
@@ -1,0 +1,26 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit'
+import type { RootState } from '../store'
+
+interface AppState {
+  count: number
+  status: 'idle' | 'loading' | 'error'
+}
+
+const initialState: AppState = { count: 0, status: 'idle' }
+
+export const appSlice = createSlice({
+  name: 'app',
+  initialState,
+  reducers: {
+    increment: (state) => { state.count += 1 },
+    decrement: (state) => { state.count -= 1 },
+    setStatus: (state, action: PayloadAction<AppState['status']>) => {
+      state.status = action.payload
+    },
+  },
+})
+
+export const { increment, decrement, setStatus } = appSlice.actions
+export const appReducer = appSlice.reducer
+export const selectCount = (state: RootState) => state.app.count
+export const selectStatus = (state: RootState) => state.app.status

--- a/catalog/nextjs/redux/files/src/store/store.ts
+++ b/catalog/nextjs/redux/files/src/store/store.ts
@@ -1,0 +1,11 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { appReducer } from './slices/appSlice'
+
+export const store = configureStore({
+  reducer: {
+    app: appReducer,
+  },
+})
+
+export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch

--- a/catalog/nextjs/redux/manifest.json
+++ b/catalog/nextjs/redux/manifest.json
@@ -1,0 +1,30 @@
+{
+  "id": "redux",
+  "name": "Redux Toolkit",
+  "description": "Redux Toolkit con store configurado, slice de ejemplo y ReduxProvider para App Router",
+  "category": "nextjs",
+  "tags": ["nextjs", "state", "redux", "redux-toolkit"],
+  "deps": {
+    "dependencies": ["@reduxjs/toolkit", "react-redux"],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/src/store/store.ts", "dest": "src/store/store.ts" },
+    { "src": "files/src/store/slices/appSlice.ts", "dest": "src/store/slices/appSlice.ts" },
+    { "src": "files/src/providers/ReduxProvider.tsx", "dest": "src/providers/ReduxProvider.tsx" }
+  ],
+  "patches": [
+    {
+      "file": "src/app/layout.tsx",
+      "operation": "append-import",
+      "content": "import { ReduxProvider } from '@/providers/ReduxProvider'"
+    },
+    {
+      "file": "src/app/layout.tsx",
+      "operation": "replace",
+      "marker": "{children}",
+      "content": "<ReduxProvider>{children}</ReduxProvider>"
+    }
+  ],
+  "docsUrl": "https://redux-toolkit.js.org/introduction/getting-started"
+}

--- a/catalog/nextjs/ui-antd/files/src/components/AntdRegistry.tsx
+++ b/catalog/nextjs/ui-antd/files/src/components/AntdRegistry.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { createCache, extractStyle, StyleProvider } from '@ant-design/cssinjs'
+import type Entity from '@ant-design/cssinjs/es/Cache'
+import { useServerInsertedHTML } from 'next/navigation'
+import React, { useRef } from 'react'
+
+export function AntdRegistry({ children }: { children: React.ReactNode }) {
+  const cache = useRef<Entity | null>(null)
+  if (!cache.current) cache.current = createCache()
+
+  useServerInsertedHTML(() => (
+    <style id="antd" dangerouslySetInnerHTML={{ __html: extractStyle(cache.current!, true) }} />
+  ))
+
+  return <StyleProvider cache={cache.current}>{children}</StyleProvider>
+}

--- a/catalog/nextjs/ui-antd/manifest.json
+++ b/catalog/nextjs/ui-antd/manifest.json
@@ -5,7 +5,7 @@
   "category": "nextjs",
   "tags": ["nextjs", "ui", "antd", "ant-design"],
   "deps": {
-    "dependencies": ["antd", "@ant-design/nextjs-registry"],
+    "dependencies": ["antd", "@ant-design/cssinjs"],
     "devDependencies": []
   },
   "files": [

--- a/catalog/nextjs/ui-antd/manifest.json
+++ b/catalog/nextjs/ui-antd/manifest.json
@@ -1,0 +1,28 @@
+{
+  "id": "ui-antd",
+  "name": "Ant Design",
+  "description": "Ant Design con AntdRegistry para compatibilidad con Next.js App Router y tema global configurado",
+  "category": "nextjs",
+  "tags": ["nextjs", "ui", "antd", "ant-design"],
+  "deps": {
+    "dependencies": ["antd", "@ant-design/nextjs-registry"],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/src/components/AntdRegistry.tsx", "dest": "src/components/AntdRegistry.tsx" }
+  ],
+  "patches": [
+    {
+      "file": "src/app/layout.tsx",
+      "operation": "append-import",
+      "content": "import { AntdRegistry } from '@/components/AntdRegistry'"
+    },
+    {
+      "file": "src/app/layout.tsx",
+      "operation": "replace",
+      "marker": "{children}",
+      "content": "<AntdRegistry>{children}</AntdRegistry>"
+    }
+  ],
+  "docsUrl": "https://ant.design/docs/react/use-with-next"
+}

--- a/catalog/nextjs/ui-mui/files/src/components/ThemeRegistry.tsx
+++ b/catalog/nextjs/ui-mui/files/src/components/ThemeRegistry.tsx
@@ -1,0 +1,16 @@
+'use client'
+import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter'
+import { ThemeProvider } from '@mui/material/styles'
+import CssBaseline from '@mui/material/CssBaseline'
+import { theme } from '@/theme/muiTheme'
+
+export function ThemeRegistry({ children }: { children: React.ReactNode }) {
+  return (
+    <AppRouterCacheProvider>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </ThemeProvider>
+    </AppRouterCacheProvider>
+  )
+}

--- a/catalog/nextjs/ui-mui/files/src/theme/muiTheme.ts
+++ b/catalog/nextjs/ui-mui/files/src/theme/muiTheme.ts
@@ -1,0 +1,12 @@
+import { createTheme } from '@mui/material/styles'
+
+export const theme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: { main: '#1976d2' },
+    secondary: { main: '#dc004e' },
+  },
+  typography: {
+    fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+  },
+})

--- a/catalog/nextjs/ui-mui/manifest.json
+++ b/catalog/nextjs/ui-mui/manifest.json
@@ -1,0 +1,29 @@
+{
+  "id": "ui-mui",
+  "name": "Material UI (MUI)",
+  "description": "Material UI v6 con ThemeRegistry para App Router, tema base configurado en modo oscuro/claro",
+  "category": "nextjs",
+  "tags": ["nextjs", "ui", "mui", "material-ui"],
+  "deps": {
+    "dependencies": ["@mui/material", "@mui/material-nextjs", "@emotion/react", "@emotion/styled", "@emotion/cache"],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/src/components/ThemeRegistry.tsx", "dest": "src/components/ThemeRegistry.tsx" },
+    { "src": "files/src/theme/muiTheme.ts", "dest": "src/theme/muiTheme.ts" }
+  ],
+  "patches": [
+    {
+      "file": "src/app/layout.tsx",
+      "operation": "append-import",
+      "content": "import { ThemeRegistry } from '@/components/ThemeRegistry'"
+    },
+    {
+      "file": "src/app/layout.tsx",
+      "operation": "replace",
+      "marker": "{children}",
+      "content": "<ThemeRegistry>{children}</ThemeRegistry>"
+    }
+  ],
+  "docsUrl": "https://mui.com/material-ui/integrations/nextjs/"
+}

--- a/catalog/nextjs/ui-radix/files/src/components/ui/Button.tsx
+++ b/catalog/nextjs/ui-radix/files/src/components/ui/Button.tsx
@@ -1,0 +1,12 @@
+import { Slot } from '@radix-ui/react-slot'
+import { type ButtonHTMLAttributes } from 'react'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean
+  variant?: 'default' | 'outline' | 'ghost'
+}
+
+export function Button({ asChild, variant = 'default', className, ...props }: ButtonProps) {
+  const Comp = asChild ? Slot : 'button'
+  return <Comp data-variant={variant} className={className} {...props} />
+}

--- a/catalog/nextjs/ui-radix/files/src/components/ui/Dialog.tsx
+++ b/catalog/nextjs/ui-radix/files/src/components/ui/Dialog.tsx
@@ -1,0 +1,23 @@
+'use client'
+import * as RadixDialog from '@radix-ui/react-dialog'
+
+export const Dialog = RadixDialog.Root
+export const DialogTrigger = RadixDialog.Trigger
+export const DialogClose = RadixDialog.Close
+
+export function DialogContent({ children, ...props }: RadixDialog.DialogContentProps) {
+  return (
+    <RadixDialog.Portal>
+      <RadixDialog.Overlay style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)' }} />
+      <RadixDialog.Content
+        style={{ position: 'fixed', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', background: 'white', padding: '1.5rem', borderRadius: '8px', minWidth: '320px' }}
+        {...props}
+      >
+        {children}
+      </RadixDialog.Content>
+    </RadixDialog.Portal>
+  )
+}
+
+export const DialogTitle = RadixDialog.Title
+export const DialogDescription = RadixDialog.Description

--- a/catalog/nextjs/ui-radix/files/src/components/ui/Popover.tsx
+++ b/catalog/nextjs/ui-radix/files/src/components/ui/Popover.tsx
@@ -1,0 +1,19 @@
+'use client'
+import * as RadixPopover from '@radix-ui/react-popover'
+
+export const Popover = RadixPopover.Root
+export const PopoverTrigger = RadixPopover.Trigger
+
+export function PopoverContent({ children, ...props }: RadixPopover.PopoverContentProps) {
+  return (
+    <RadixPopover.Portal>
+      <RadixPopover.Content
+        style={{ background: 'white', padding: '1rem', borderRadius: '6px', boxShadow: '0 2px 8px rgba(0,0,0,0.15)' }}
+        sideOffset={4}
+        {...props}
+      >
+        {children}
+      </RadixPopover.Content>
+    </RadixPopover.Portal>
+  )
+}

--- a/catalog/nextjs/ui-radix/manifest.json
+++ b/catalog/nextjs/ui-radix/manifest.json
@@ -1,0 +1,18 @@
+{
+  "id": "ui-radix",
+  "name": "Radix UI Primitives",
+  "description": "Radix UI con componentes base sin estilos — Button, Dialog y Popover listos para personalizar",
+  "category": "nextjs",
+  "tags": ["nextjs", "ui", "radix", "radix-ui", "primitives"],
+  "deps": {
+    "dependencies": ["@radix-ui/react-dialog", "@radix-ui/react-popover", "@radix-ui/react-slot"],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/src/components/ui/Button.tsx", "dest": "src/components/ui/Button.tsx" },
+    { "src": "files/src/components/ui/Dialog.tsx", "dest": "src/components/ui/Dialog.tsx" },
+    { "src": "files/src/components/ui/Popover.tsx", "dest": "src/components/ui/Popover.tsx" }
+  ],
+  "patches": [],
+  "docsUrl": "https://www.radix-ui.com/primitives/docs/overview/introduction"
+}

--- a/catalog/nextjs/zustand/files/src/store/useAppStore.ts
+++ b/catalog/nextjs/zustand/files/src/store/useAppStore.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand'
+
+interface AppState {
+  count: number
+  user: { name: string; email: string } | null
+  increment: () => void
+  decrement: () => void
+  setUser: (user: AppState['user']) => void
+  reset: () => void
+}
+
+export const useAppStore = create<AppState>((set) => ({
+  count: 0,
+  user: null,
+  increment: () => set((state) => ({ count: state.count + 1 })),
+  decrement: () => set((state) => ({ count: state.count - 1 })),
+  setUser: (user) => set({ user }),
+  reset: () => set({ count: 0, user: null }),
+}))
+
+// Selector hooks for optimized re-renders
+export const useCount = () => useAppStore((state) => state.count)
+export const useUser = () => useAppStore((state) => state.user)

--- a/catalog/nextjs/zustand/manifest.json
+++ b/catalog/nextjs/zustand/manifest.json
@@ -1,0 +1,16 @@
+{
+  "id": "zustand",
+  "name": "Zustand",
+  "description": "Estado global con Zustand — store base con slice de ejemplo y patrón de selectors",
+  "category": "nextjs",
+  "tags": ["nextjs", "state", "zustand"],
+  "deps": {
+    "dependencies": ["zustand"],
+    "devDependencies": []
+  },
+  "files": [
+    { "src": "files/src/store/useAppStore.ts", "dest": "src/store/useAppStore.ts" }
+  ],
+  "patches": [],
+  "docsUrl": "https://docs.pmnd.rs/zustand/getting-started/introduction"
+}

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process'
 import { fetchCatalogIndex, fetchCategoryIndex, fetchManifest } from '../lib/fetcher.js'
-import { installFiles } from '../lib/installer.js'
+import { installFiles, applyPatches } from '../lib/installer.js'
 import { detectPackageManager, getInstallCommand } from '../lib/package-manager.js'
 import type { CategoryRef, ManifestItem, InstallStep } from '../types.js'
 
@@ -34,6 +34,13 @@ export async function runInstall(
     const fileResults = await installFiles(manifest, cwd)
     for (const result of fileResults) {
       onStep({ label: result.path, status: result.error ? 'error' : result.skipped ? 'skipped' : 'done' })
+    }
+
+    if (manifest.patches && manifest.patches.length > 0) {
+      const patchResults = await applyPatches(manifest.patches, cwd)
+      for (const result of patchResults) {
+        onStep({ label: `patch: ${result.path}`, status: result.error ? 'error' : result.skipped ? 'skipped' : 'done' })
+      }
     }
 
     if (manifest.deps.dependencies.length > 0) {

--- a/packages/cli/src/lib/installer.test.ts
+++ b/packages/cli/src/lib/installer.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs'
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
-import { installFiles } from './installer.js'
+import { installFiles, applyPatches } from './installer.js'
 import * as fetcher from './fetcher.js'
-import type { ManifestItem } from '../types.js'
+import type { ManifestItem, ManifestPatch } from '../types.js'
 
 vi.mock('./fetcher.js')
 
@@ -83,5 +83,104 @@ describe('installFiles', () => {
     const results = await installFiles(mockManifest, tmpDir)
     expect(results[0].skipped).toBe(false)
     expect(results[0].error).toBe('Network error fetching file')
+  })
+})
+
+describe('applyPatches', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'patches-test-'))
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true })
+  })
+
+  it('prepend: inserta el contenido al inicio del archivo', async () => {
+    const filePath = join(tmpDir, 'target.ts')
+    writeFileSync(filePath, 'const existing = true\n', 'utf-8')
+
+    const patches: ManifestPatch[] = [
+      { file: 'target.ts', operation: 'prepend', content: '// prepended line' },
+    ]
+
+    const results = await applyPatches(patches, tmpDir)
+
+    expect(results).toHaveLength(1)
+    expect(results[0].skipped).toBe(false)
+    const written = readFileSync(filePath, 'utf-8')
+    expect(written.startsWith('// prepended line')).toBe(true)
+  })
+
+  it('append: inserta el contenido al final del archivo', async () => {
+    const filePath = join(tmpDir, 'target.ts')
+    writeFileSync(filePath, 'const existing = true\n', 'utf-8')
+
+    const patches: ManifestPatch[] = [
+      { file: 'target.ts', operation: 'append', content: '// appended line' },
+    ]
+
+    const results = await applyPatches(patches, tmpDir)
+
+    expect(results[0].skipped).toBe(false)
+    const written = readFileSync(filePath, 'utf-8')
+    expect(written.endsWith('// appended line')).toBe(true)
+  })
+
+  it('append-import: inserta la línea después del último import', async () => {
+    const filePath = join(tmpDir, 'layout.tsx')
+    writeFileSync(
+      filePath,
+      `import React from 'react'\nimport { Foo } from './foo'\n\nexport default function Layout() {}\n`,
+      'utf-8'
+    )
+
+    const patches: ManifestPatch[] = [
+      {
+        file: 'layout.tsx',
+        operation: 'append-import',
+        content: "import { Bar } from './bar'",
+      },
+    ]
+
+    await applyPatches(patches, tmpDir)
+
+    const written = readFileSync(filePath, 'utf-8')
+    const lines = written.split('\n')
+    const barIndex = lines.indexOf("import { Bar } from './bar'")
+    const fooIndex = lines.indexOf("import { Foo } from './foo'")
+    expect(barIndex).toBeGreaterThan(fooIndex)
+  })
+
+  it('replace: sustituye el marker por el contenido', async () => {
+    const filePath = join(tmpDir, 'layout.tsx')
+    writeFileSync(filePath, '<main>PLACEHOLDER</main>\n', 'utf-8')
+
+    const patches: ManifestPatch[] = [
+      {
+        file: 'layout.tsx',
+        operation: 'replace',
+        marker: 'PLACEHOLDER',
+        content: '<Wrapper>{children}</Wrapper>',
+      },
+    ]
+
+    await applyPatches(patches, tmpDir)
+
+    const written = readFileSync(filePath, 'utf-8')
+    expect(written).toContain('<Wrapper>{children}</Wrapper>')
+    expect(written).not.toContain('PLACEHOLDER')
+  })
+
+  it('file-not-exists: retorna skipped:true si el archivo no existe', async () => {
+    const patches: ManifestPatch[] = [
+      { file: 'nonexistent.tsx', operation: 'prepend', content: '// something' },
+    ]
+
+    const results = await applyPatches(patches, tmpDir)
+
+    expect(results).toHaveLength(1)
+    expect(results[0].skipped).toBe(true)
   })
 })

--- a/packages/cli/src/lib/installer.ts
+++ b/packages/cli/src/lib/installer.ts
@@ -1,7 +1,7 @@
-import { writeFileSync, mkdirSync, existsSync } from 'fs'
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
 import { join, dirname } from 'path'
 import { fetchFile } from './fetcher.js'
-import type { ManifestItem, InstallResult } from '../types.js'
+import type { ManifestItem, ManifestPatch, InstallResult } from '../types.js'
 
 export async function installFiles(
   manifest: ManifestItem,
@@ -28,6 +28,71 @@ export async function installFiles(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       results.push({ path: file.dest, skipped: false, error: message })
+    }
+  }
+
+  return results
+}
+
+export async function applyPatches(
+  patches: ManifestPatch[],
+  cwd: string
+): Promise<InstallResult[]> {
+  const results: InstallResult[] = []
+
+  for (const patch of patches) {
+    const filePath = join(cwd, patch.file)
+
+    if (!existsSync(filePath)) {
+      results.push({ path: patch.file, skipped: true })
+      continue
+    }
+
+    try {
+      let content = readFileSync(filePath, 'utf-8')
+
+      switch (patch.operation) {
+        case 'prepend':
+          content = patch.content + '\n' + content
+          break
+        case 'append':
+          content = content + '\n' + patch.content
+          break
+        case 'append-import': {
+          // Insert after the last 'import ' line
+          const lines = content.split('\n')
+          let lastImportIndex = -1
+          for (let i = 0; i < lines.length; i++) {
+            if (lines[i].trimStart().startsWith('import ')) {
+              lastImportIndex = i
+            }
+          }
+          if (lastImportIndex >= 0) {
+            lines.splice(lastImportIndex + 1, 0, patch.content)
+          } else {
+            lines.unshift(patch.content)
+          }
+          content = lines.join('\n')
+          break
+        }
+        case 'replace':
+          if (!patch.marker) {
+            results.push({ path: patch.file, skipped: false, error: 'replace operation requires a marker' })
+            continue
+          }
+          if (!content.includes(patch.marker)) {
+            results.push({ path: patch.file, skipped: true })
+            continue
+          }
+          content = content.replace(patch.marker, patch.content)
+          break
+      }
+
+      writeFileSync(filePath, content, 'utf-8')
+      results.push({ path: patch.file, skipped: false })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      results.push({ path: patch.file, skipped: false, error: message })
     }
   }
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -21,11 +21,12 @@ export interface DepsMap {
   devDependencies: string[]
 }
 
-export type PatchOperation = 'prepend' | 'append' | 'append-import'
+export type PatchOperation = 'prepend' | 'append' | 'append-import' | 'replace'
 
 export interface ManifestPatch {
   file: string
   operation: PatchOperation
+  marker?: string
   content: string
 }
 


### PR DESCRIPTION
Closes #114

## Summary
- Adds 11 integration modules under `catalog/nextjs/`: auth, react-query, react-hook-form, ui-antd, ui-mui, ui-radix, i18n, zustand, redux, dayjs, currency
- Extends `packages/cli/src/lib/installer.ts` with `applyPatches()` supporting prepend, append, append-import, and replace operations
- Updates `packages/cli/src/types.ts` to add `'replace'` to `PatchOperation` and `marker?` field to `ManifestPatch`
- Updates `packages/cli/src/commands/add.ts` to call `applyPatches()` after `installFiles()`
- Updates `catalog/nextjs/index.json` to register all 11 modules

## Test plan
- [x] All 12 JSON files validated with `node -e "JSON.parse(...)"` — no errors
- [x] CLI builds cleanly with `pnpm build` — `ESM Build success`
- [x] All 11 module directories exist under `catalog/nextjs/`
- [x] All `manifest.files` entries have matching files under `files/`
- [ ] Live integration test (TUI loading modules from GitHub) — blocked until PR merges to main (CLI fetches from raw `main` branch URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)