### PR TITLE
feat: homepage redesign — split layout al estilo autoskills.sh

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -85,14 +85,16 @@ export default function Home() {
           >
             GitHub
           </a>
-          <span>·</span>
           {firstDoc && (
-            <Link
-              href={`/docs/${firstDoc.slug.join('/')}`}
-              className="hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
-            >
-              Documentación
-            </Link>
+            <>
+              <span>·</span>
+              <Link
+                href={`/docs/${firstDoc.slug.join('/')}`}
+                className="hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
+              >
+                Documentación
+              </Link>
+            </>
           )}
           <span>·</span>
           <span>npm · pnpm · yarn</span>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { existsSync } from 'fs'
 import { join } from 'path'
 import { getAllDocs } from '@/lib/docs'
 import { TerminalFrame, TerminalFramePlaceholder } from '@/components/TerminalFrame/TerminalFrame'
+import { UseCaseCard } from '@/components/UseCaseCard'
 
 function hasDemoGif() {
   return existsSync(join(process.cwd(), 'public', 'demo.gif'))
@@ -15,59 +16,92 @@ export default function Home() {
   const showDemo = hasDemoGif()
 
   return (
-    <div className="flex flex-col items-start max-w-3xl mx-auto px-6 py-16">
-      {/* Hero */}
-      <div className="mb-2 text-xs font-semibold uppercase tracking-widest text-zinc-400 dark:text-zinc-500">
-        Personal Playbook
-      </div>
+    <div className="flex flex-col lg:flex-row min-h-full">
+      {/* ── Left: scrollable content ── */}
+      <section className="w-full lg:w-[55%] px-10 py-20 xl:px-16 flex flex-col gap-20">
 
-      <h1 className="text-4xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50 mb-4">
-        Sanghel Playbook
-      </h1>
-
-      <p className="text-lg text-zinc-500 dark:text-zinc-400 leading-relaxed mb-10">
-        Patterns, components, architectural decisions, and lessons learned.
-        A living reference built in the open.
-      </p>
-
-      <div className="flex gap-3 mb-20">
-        {firstDoc ? (
-          <Link
-            href={`/docs/${firstDoc.slug.join('/')}`}
-            className="inline-flex items-center gap-2 rounded-lg bg-zinc-900 dark:bg-white px-4 py-2 text-sm font-medium text-white dark:text-zinc-900 hover:opacity-80 transition-opacity"
-          >
-            Get started
-            <span>→</span>
-          </Link>
-        ) : (
-          <span className="text-sm text-zinc-400 dark:text-zinc-500 italic">
-            No docs yet — add an .mdx file to src/content/docs/ to get started.
+        {/* Hero */}
+        <div className="flex flex-col gap-6">
+          <span className="text-xs font-semibold uppercase tracking-widest text-zinc-400 dark:text-zinc-500">
+            CLI · Scaffolding
           </span>
-        )}
-
-        <a
-          href="https://github.com/Sanghel/sanghel-playbook"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 rounded-lg border border-zinc-200 dark:border-zinc-700 px-4 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-300 hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors"
-        >
-          GitHub
-        </a>
-      </div>
-
-      {/* Demo section */}
-      <div className="w-full">
-        <div className="mb-2 text-xs font-semibold uppercase tracking-widest text-zinc-400 dark:text-zinc-500">
-          CLI / TUI
+          <h1 className="text-4xl xl:text-5xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50 leading-tight">
+            Arranca tu proyecto<br />con todo lo que necesitas
+          </h1>
+          <p className="text-lg text-zinc-500 dark:text-zinc-400 leading-relaxed max-w-lg">
+            Crea proyectos Next.js, React+Vite y Astro con las integraciones que elijas, configuradas y listas para usar.
+          </p>
+          <div className="flex items-center gap-3 flex-wrap">
+            <code className="font-mono text-sm bg-zinc-900 dark:bg-zinc-800 text-green-400 px-3 py-1.5 rounded-lg border border-zinc-700">
+              npx sanghel-playbook
+            </code>
+            {firstDoc && (
+              <Link
+                href={`/docs/${firstDoc.slug.join('/')}`}
+                className="text-sm font-medium text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-50 transition-colors"
+              >
+                Ver documentación →
+              </Link>
+            )}
+          </div>
         </div>
-        <h2 className="text-2xl font-bold tracking-tight text-zinc-900 dark:text-zinc-50 mb-3">
-          Instala patrones desde la terminal
-        </h2>
-        <p className="text-base text-zinc-500 dark:text-zinc-400 mb-8">
-          Crea proyectos con tu stack favorito, aplica templates con branding propio
-          y añade patrones al instante — sin copiar código.
-        </p>
 
+        {/* Use case cards */}
+        <div className="flex flex-col gap-6">
+          <UseCaseCard
+            title="Next.js con autenticación completa"
+            description="Proyecto listo con NextAuth v5, sesiones y Credentials provider configurado. Solo añade tu base de datos."
+            chips={['NextAuth v5', 'App Router', 'TypeScript']}
+          />
+          <UseCaseCard
+            title="React + Vite con estado y formularios"
+            description="Zustand para estado global, React Hook Form con validación Zod y React Query para fetching de datos."
+            chips={['Zustand', 'React Query', 'Hook Form', 'Zod']}
+          />
+          <UseCaseCard
+            title="Next.js internacionalizado"
+            description="i18next configurado con archivos de traducción en español e inglés y detección automática de idioma."
+            chips={['i18next', 'Next.js', 'ES · EN']}
+          />
+          <UseCaseCard
+            title="React + Vite con UI y routing"
+            description="React Router DOM con rutas base, Ant Design con tema global y utilidades de formato de fechas y moneda."
+            chips={['React Router', 'Ant Design', 'Day.js']}
+          />
+          <UseCaseCard
+            title="Astro con auth y estado"
+            description="Lucia Auth con sesiones basadas en cookies, Nanostores para estado reactivo entre islas."
+            chips={['Lucia Auth', 'Nanostores', 'Astro']}
+          />
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center gap-4 text-sm text-zinc-400 dark:text-zinc-500 pb-8">
+          <a
+            href="https://github.com/Sanghel/sanghel-playbook"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
+          >
+            GitHub
+          </a>
+          <span>·</span>
+          {firstDoc && (
+            <Link
+              href={`/docs/${firstDoc.slug.join('/')}`}
+              className="hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors"
+            >
+              Documentación
+            </Link>
+          )}
+          <span>·</span>
+          <span>npm · pnpm · yarn</span>
+        </div>
+
+      </section>
+
+      {/* ── Right: sticky terminal ── */}
+      <aside className="hidden lg:flex lg:w-[45%] sticky top-0 h-screen items-center justify-center bg-zinc-950 dark:bg-[#0a0a0a] p-8 border-l border-zinc-800">
         {showDemo ? (
           <TerminalFrame>
             <Image
@@ -84,44 +118,40 @@ export default function Home() {
             <DemoPlaceholder />
           </TerminalFramePlaceholder>
         )}
-
-        <p className="mt-4 text-sm text-zinc-400 dark:text-zinc-500">
-          <code className="font-mono text-xs bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded">
-            npx sanghel-playbook
-          </code>
-          {' '}— funciona con npm, pnpm y yarn.
-        </p>
-      </div>
+      </aside>
     </div>
   )
 }
 
 function DemoPlaceholder() {
   return (
-    <div className="flex flex-col gap-3 p-6 min-h-[260px] justify-center font-mono text-sm">
+    <div className="flex flex-col gap-3 p-6 min-h-[320px] justify-center font-mono text-sm">
       <div className="flex gap-2 items-center">
         <span className="text-zinc-600">$</span>
         <span className="text-zinc-300">npx sanghel-playbook</span>
       </div>
-      <div className="pl-4 flex flex-col gap-1 text-zinc-400">
-        <div>
-          <span className="text-green-400">▶</span>
-          {' '}Crear nuevo proyecto
-        </div>
+      <div className="pl-4 flex flex-col gap-1 text-zinc-400 mt-1">
+        <div><span className="text-green-400">▶</span>{' '}Crear nuevo proyecto</div>
         <div className="text-zinc-600">  Añadir a proyecto existente</div>
       </div>
-      <div className="pl-4 flex flex-col gap-1 text-zinc-400 mt-1">
-        <div className="text-zinc-500 text-xs">Selecciona el stack base:</div>
-        <div>
-          <span className="text-green-400">▶</span>
-          {' '}React + Vite
-          <span className="text-zinc-600 text-xs ml-2">Welcome module · components/ · hooks/</span>
-        </div>
-        <div className="text-zinc-600">  Next.js (create-next-app)</div>
+      <div className="pl-4 flex flex-col gap-1 text-zinc-400 mt-2">
+        <div className="text-zinc-500 text-xs">Elige el stack base:</div>
+        <div><span className="text-green-400">▶</span>{' '}Next.js</div>
+        <div className="text-zinc-600">  React + Vite</div>
         <div className="text-zinc-600">  Astro</div>
       </div>
-      <div className="mt-3 text-zinc-600 text-xs italic">
-        — Graba el GIF con: vhs demo.tape
+      <div className="pl-4 flex flex-col gap-1 text-zinc-400 mt-2">
+        <div className="text-zinc-500 text-xs">Gestor de paquetes:</div>
+        <div><span className="text-green-400">▶</span>{' '}pnpm</div>
+        <div className="text-zinc-600">  npm</div>
+        <div className="text-zinc-600">  yarn</div>
+      </div>
+      <div className="pl-4 flex flex-col gap-1 text-zinc-400 mt-2">
+        <div className="text-zinc-500 text-xs">Integraciones para Next.js:</div>
+        <div><span className="text-zinc-500 text-xs">[ ]</span>{' '}<span className="text-zinc-400">NextAuth v5</span></div>
+        <div><span className="text-green-400 text-xs">[✓]</span>{' '}<span className="text-green-400">React Query</span></div>
+        <div><span className="text-green-400 text-xs">[✓]</span>{' '}<span className="text-green-400">Zustand</span></div>
+        <div><span className="text-zinc-500 text-xs">[ ]</span>{' '}<span className="text-zinc-400">i18next</span></div>
       </div>
     </div>
   )

--- a/src/components/UseCaseCard/UseCaseCard.tsx
+++ b/src/components/UseCaseCard/UseCaseCard.tsx
@@ -1,0 +1,28 @@
+interface UseCaseCardProps {
+  title: string
+  description: string
+  chips: string[]
+}
+
+export function UseCaseCard({ title, description, chips }: UseCaseCardProps) {
+  return (
+    <div className="group rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-6 hover:border-zinc-300 dark:hover:border-zinc-700 transition-colors">
+      <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-50 mb-2">
+        {title}
+      </h3>
+      <p className="text-sm text-zinc-500 dark:text-zinc-400 leading-relaxed mb-4">
+        {description}
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {chips.map((chip) => (
+          <span
+            key={chip}
+            className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300"
+          >
+            {chip}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/components/UseCaseCard/UseCaseCard.tsx
+++ b/src/components/UseCaseCard/UseCaseCard.tsx
@@ -6,7 +6,7 @@ interface UseCaseCardProps {
 
 export function UseCaseCard({ title, description, chips }: UseCaseCardProps) {
   return (
-    <div className="group rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-6 hover:border-zinc-300 dark:hover:border-zinc-700 transition-colors">
+    <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 p-6 hover:border-zinc-300 dark:hover:border-zinc-700 transition-colors">
       <h3 className="text-base font-semibold text-zinc-900 dark:text-zinc-50 mb-2">
         {title}
       </h3>

--- a/src/components/UseCaseCard/index.ts
+++ b/src/components/UseCaseCard/index.ts
@@ -1,0 +1,1 @@
+export { UseCaseCard } from './UseCaseCard'


### PR DESCRIPTION
## Summary

- Rewrites `src/app/page.tsx` with a 55/45 split layout (left scrolls, right sticky terminal)
- Creates `UseCaseCard` component with title, description, and chip badges
- Mobile-responsive: single column on < lg, terminal hidden on small screens
- Updated `DemoPlaceholder` to reflect the new scaffolding flow

Closes #120

## Test plan

- [ ] Open http://localhost:3000 — split layout visible (left content + right terminal)
- [ ] Scroll the page — left content scrolls, right terminal stays sticky
- [ ] Resize viewport below 1024px — single column, terminal hidden
- [ ] `pnpm build` passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)